### PR TITLE
Docs/phase0

### DIFF
--- a/.github/ISSUE_TEMPLATE/spec_review.md
+++ b/.github/ISSUE_TEMPLATE/spec_review.md
@@ -1,0 +1,30 @@
+---
+name: Spec Review
+about: Lightweight intake to review and accept a spec into MVP scope
+title: "Spec: <short-title>"
+labels: ["spec"]
+assignees: []
+---
+
+Because  
+Briefly explain why this spec is needed now and who benefits.
+
+Doc link  
+While in review, paste the PR URL or branch file path (e.g., https://github.com/<repo>/pull/123 or the branch file URL). After acceptance, update to the main-branch path (e.g., docs/specs/04_Intake_MVP_Specs.md).
+
+Acceptance bullets  
+- [ ] Behavior and scope are clear (what users can do)  
+- [ ] Out of scope explicitly listed  
+- [ ] Flags (if needed): owner, default, kill switch, removal date  
+- [ ] Migrations (if any): expand → migrate → contract plan exists  
+- [ ] Observability: what we’ll watch after release (smoke + key metrics)
+
+Dependencies / risks  
+List notable risks, escalations, or cross-cutting dependencies.
+
+Project fields  
+Status = Draft; Type = Spec; Area = <intake|identity|measure|chronicle|lexicon|ui|db|ci|policy|runbooks>; Target Release = mvp-<X.Y.Z>
+
+Links  
+PR (if opened):  
+Related Issues:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,64 @@
+<!--
+Intent-first PR template
+Read the checklist; delete guidance before submitting.
+Terms link to the Glossary: docs/reference/glossary.md
+-->
+
+# Because
+<!-- One crisp sentence on the pain, risk, or opportunity.
+Example: "Chef cannot save drafts across sessions, causing data loss on refresh." -->
+
+# Changed
+<!-- Minimal surfaces touched; be explicit about what you did NOT change. -->
+
+# Result
+<!-- User/system outcome. Screenshots or brief notes if applicable. -->
+
+# Done when
+- [ ] Acceptance criterion 1
+- [ ] Acceptance criterion 2
+- [ ] Acceptance criterion 3 (optional)
+
+# Out of scope
+<!-- Temptations you explicitly skipped; create Issues for follow-ups. -->
+
+# Flags
+<!-- Feature flags changed/added. One per line: name, default, owner, planned removal date.
+See: docs/policy/env_and_secrets.md -->
+- flag: `example_flag`
+  - default: OFF
+  - owner: you
+  - removal: `2025-12-31`
+
+# Migrations
+<!-- Note if schema/data changes follow Expand → Migrate → Contract.
+Add script names like `migrations/sql/V00X__desc.sql`.
+See: docs/policy/ci_cd_constitution.md -->
+- Plan: Expand → Migrate → Contract
+- Scripts: `V00X__add_column.sql`, `V00Y__backfill_values.sql`
+
+# Observability
+<!-- How this shows up in logs/metrics/events; add deploy markers as needed.
+Include version, tenant_id, request_id, correlation_id. -->
+- Deploy marker: yes / no
+- Key metrics to watch: …
+- Event name(s): …
+
+# Risks / Rollback
+<!-- What could go wrong and how to revert (artifact rollback or flag OFF). -->
+
+# Changelog
+<!-- One human sentence for release notes (Keep a Changelog style).
+See: docs/policy/commits_and_changelog.md -->
+Added — …
+Changed — …
+Fixed — …
+
+---
+
+## Meta
+
+- Branch: `feat/short-slug` or `fix/short-slug` (see docs/policy/branching_and_prs.md)
+- Conventional commit prefix for squash: `feat(scope): subject` (see docs/policy/commits_and_changelog.md)
+- CI expectations (lint/tests/smoke): see docs/policy/ci_minimal.md
+- Terms: see docs/reference/glossary.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,105 @@
+# CONTRIBUTING (MVP)
+**Updated:** 2025-09-19 13:23
+
+Audience: solo/tiny team. Purpose: make work small, visible, and reversible. Terms link to the [Glossary](docs/reference/glossary.md).  
+Examples of filenames in this document are wrapped in backticks to avoid accidental links (e.g., `VERSION`, `V003__add_tenant_id.sql`).
+
+---
+
+## How we work
+- **Trunk-based**: `main` is always releasable. No permanent `develop`.
+- **Small branches**: open a **Draft PR** immediately, keep scope tight, merge quickly.
+- **Squash-merge** to `main`; delete branches after merge.
+- Build once, promote the **same artifact** to staging then production.
+
+See: [Branching & PR Protocol](docs/policy/branching_and_prs.md).
+
+---
+
+## Branches & naming
+Use lowercase with slashes: `feat/short-slug`, `fix/short-slug`, `docs/policy-…`, `chore/…`, `ci/…`, `refactor/…`, `test/…`.  
+Open a Draft PR as soon as you branch.
+
+---
+
+## Pull requests (intent-first)
+Use the template at `.github/pull_request_template.md`. Fill **Because / Changed / Result / Done when / Out of scope / Flags / Migrations / Observability / Changelog**.  
+Graduate from Draft when acceptance bullets pass locally and checks are nearly green.
+
+---
+
+## Definition of Ready / Done
+**Ready** (leave Draft):
+- One change story, clearly scoped.
+- Acceptance bullets are specific and testable.
+- Rollback plan (artifact or flag OFF).
+- If schema changes: **Expand → Migrate → Contract** plan exists.
+
+**Done** (merge):
+- All required checks pass (see [Minimal CI](docs/policy/ci_minimal.md)).
+- Observability: deploy marker considered; IDs present (version, tenant, request, correlation).
+- **CHANGELOG** line written in the PR.
+- Related docs/flags updated if needed.
+
+---
+
+## Required checks (Week 1)
+- Style: ruff + formatter in check mode.
+- Tests: unit + thin smoke (Golden Path).  
+- No flaky tests; quarantine or fix within 48h.
+
+See: [Minimal CI (Week 1)](docs/policy/ci_minimal.md).
+
+---
+
+## Commits & changelog
+Follow **Conventional Commits**: `type(scope): subject`. One intent per commit.  
+Use scopes like `intake`, `identity`, `measure`, `chronicle`, `lexicon`, `ui`, `db`, `ci`, `policy`, `runbooks`.  
+Curate human-friendly entries in `CHANGELOG.md` (Keep a Changelog).
+
+See: [Commits & Changelog](docs/policy/commits_and_changelog.md).
+
+---
+
+## Environments & secrets
+- SimplerTree: **staging** (auto on merge) → **production** (manual approval).  
+- Secrets live in GitHub **Environments** (`staging`, `production`); repo contains only templates: `.env.example`, `.streamlit/secrets.toml.example`.  
+- Never echo secrets in logs.
+
+See: [Environments & Secrets](docs/policy/env_and_secrets.md).
+
+---
+
+## Releases
+- Version in `VERSION`; tags from `main` as `mvp-X.Y.Z` (pre-1.0: bump **Y** for features/breaking; **Z** for fixes).  
+- Use the [Release Playbook](docs/runbooks/release_playbook.md): bump → tag → staging → smoke → approve → prod → aftercare.
+
+---
+
+## Migrations & flags
+- **Migrations**: keep scripts idempotent under `migrations/sql/` (e.g., `V003__add_tenant_id.sql`); follow **Expand → Migrate → Contract**.  
+- **Feature flags**: merge early, release later; define owner, default, removal date; support cohort rollout and kill switch.
+
+See: [CI/CD Constitution](docs/policy/ci_cd_constitution.md).
+
+---
+
+## Docs
+- The docs index is at `docs/README.md` (Project Bible). If a page exists and isn’t linked there, add it.  
+- Put accepted specs in `docs/specs/`; use `docs/adr/` for small, dated decisions.  
+- Trackers and active plans live in GitHub Issues/Projects; heavy notes in OneDrive.
+
+See: [Docs Policy & Map](docs/policy/docs_policy.md).
+
+---
+
+## House style (quick)
+- Keep PRs reviewable in ~15 minutes; split if larger.
+- Avoid “wip/misc fixes” subjects.
+- Prefer links to terms in the **Glossary** on first mention.
+- Example filenames are wrapped in backticks (e.g., `supabase_schema_2025-09-16_01.sql`).
+
+---
+
+## Contact
+Owner: Mathieu Fortin. Review cadence: quick scan monthly; deeper pass per release.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,44 @@
+# Project Bible (Index)
+**Updated:** 2025-09-18 19:08
+
+This is the single entrypoint to all project documentation. Each link is marked as [MVP] or [v1].  
+Repo = Library (durable truth). GitHub = Town Square (work-in-progress). OneDrive = heavy files & research.
+
+> Tip: Need a term? Jump to the [Glossary](reference/glossary.md).
+
+## CI/CD & Governance
+- [Docs Policy & Map](policy/docs_policy.md) — what lives where; includes the commit intent decision tree. [MVP]
+- [CI/CD Constitution](policy/ci_cd_constitution.md) — principles, gates, environments. [MVP]
+- [Branching & PR Protocol](policy/branching_and_prs.md) — trunk-based, Draft PRs, squash. [MVP]
+- [Conventional Commits & Changelog](policy/commits_and_changelog.md) — commit types, tags, CHANGELOG. [MVP]
+- [Minimal CI (Week 1)](policy/ci_minimal.md) — required checks and shape of Actions. [MVP]
+- [.github/PULL_REQUEST_TEMPLATE.md](../.github/pull_request_template.md) — intent-first structure. [MVP]
+
+## Runbooks
+- [Release Playbook](runbooks/release_playbook.md) — bump → verify → tag → stage → promote → aftercare. [MVP]
+- First Run — (to be added in Phase 1). [MVP]
+- Rollback — (to be added in Phase 2). [v1]
+
+## Environments & Secrets
+- [Environments & Secrets](policy/env_and_secrets.md) — SimplerTree; Supabase staging/prod; GitHub Environments. [MVP]
+
+## Reference
+- [Glossary](reference/glossary.md) — shared language across docs and PRs. [MVP]
+- Data Dictionary — add link under `docs/reference/` when ready. [MVP]
+- Events & Error Model — Phase 3. [v1]
+
+## Specs / ADRs
+- Accepted specs live in `docs/specs/` (Phase 1 adds an index). [MVP]
+- ADRs live in `docs/adr/` (template arrives in Phase 2). [v1]
+
+## Work Tracking & Heavy Files (update these URLs)
+- GitHub Issues: <repo issues URL>
+- GitHub Projects: <project board URL>
+- GitHub Discussions (optional): <URL>
+- OneDrive root for this project: <path>
+
+---
+**How to use this index**  
+• If a document exists but isn’t listed here, add it — the map is the contract.  
+• When a doc spans MVP and v1, label sections inside the doc “MVP now” vs “v1 later”.  
+• When giving examples of filenames, wrap them in backticks to avoid accidental links (e.g., `2025-08-19-title.md`).

--- a/docs/policy/branching_and_prs.md
+++ b/docs/policy/branching_and_prs.md
@@ -1,0 +1,144 @@
+# Branching & PR Protocol (Solo Edition)
+**Updated:** 2025-09-18 19:35
+
+Purpose: make changes small, visible, and reversible. This protocol encodes **trunk-based development** and an **intent-first** pull request habit so you ship steadily without fear. Terms link to the [Glossary](../reference/glossary.md) (e.g., [Trunk-Based Development](../reference/glossary.md#trunk-based-development), [CI](../reference/glossary.md#ci-continuous-integration), [SemVer](../reference/glossary.md#semver-semantic-versioning)).
+
+---
+
+## 1) Principles
+- **Trunk-only**: `main` is always releasable. No permanent `develop` branch.  
+- **Short-lived branches**: aim for hours or a day or two, not weeks.  
+- **Open a Draft PR immediately**: declare intent early, keep scope honest. Use the template in [.github/pull_request_template.md](../../.github/pull_request_template.md).  
+- **Squash-merge** into `main`: linear, human history; delete branches after merge.  
+- **Build once, promote**: releases are cut from `main` and tagged `mvp-X.Y.Z`. See the [Release Playbook](../runbooks/release_playbook.md).
+
+---
+
+## 2) Branch naming
+Use lowercase, kebab-case segments; choose a **type** + short slug:
+
+- `feat/…` new user-visible behavior ([feat](../reference/glossary.md#fix-commit-type) in Conventional Commits)  
+- `fix/…` bug fix in runtime behavior  
+- `chore/…` config/deps; `build/…` packaging; `ci/…` workflows  
+- `refactor/…` internal change; `perf/…` performance; `docs/…` docs-only; `test/…` tests-only
+
+**Examples**  
+- `feat/intake-uom-normalization`  
+- `fix/tenant-switcher-null`  
+- `chore/deps-ruff-0-6`
+
+If linking to a GitHub Issue, optionally suffix with the issue number: `feat/intake-uom-normalization-#123`.
+
+---
+
+## 3) Lifecycle of a PR
+### Step A — Branch & Draft
+1. Branch from `main`. Example: `feat/tenant-claim-wizard`.  
+2. Open a **Draft PR** using the intent-first template. Fill in **Because** and **Done when** first.  
+3. If your work spans multiple pieces, create an **umbrella** Draft PR and link child PRs.
+
+### Step B — Keep it small
+- If your PR exceeds ~400–600 changed lines, ask: *what can I trim or split?*  
+- Save big rewrites for v1 or split across micro-PRs coordinated by an umbrella PR.
+
+### Step C — Commit style
+- Follow [Conventional Commits & Changelog](commits_and_changelog.md).  
+- One **intent** per commit. If you did two different things, make two commits.  
+- Use a **scope** when helpful: `feat(intake): normalize UOM on import`.
+
+### Step D — Ready for review
+A PR graduates from Draft when:  
+- All acceptance bullets in **Done when** pass locally.  
+- Required checks from [Minimal CI (Week 1)](ci_minimal.md) are close to green.  
+- **Migrations** (if any) follow Expand → Migrate → Contract (see [CI/CD Constitution](ci_cd_constitution.md)).  
+- **Observability** notes filled (version, tenant_id, request_id, correlation_id).
+
+### Step E — Merge
+- **Squash-merge** into `main`.  
+- Squash title should be a Conventional Commit:  
+  `feat(scope): short subject`  
+  Body: a tight **Because / Changed / Result** summary (copy from the PR).  
+- Delete the branch.
+
+### Step F — After merge
+- `main` deploys to **staging** automatically; post-deploy **smoke** runs (see [Minimal CI (Week 1)](ci_minimal.md)).  
+- When staging looks good, promote to **production** per the [Release Playbook](../runbooks/release_playbook.md).
+
+---
+
+## 4) Definition of Ready & Done
+**Ready (to leave Draft)**  
+- Scope is tight (one change story).  
+- Acceptance bullets are specific and testable.  
+- Rollback plan exists (artifact rollback or flag OFF).  
+- If schema changed, **migrations** plan is written (see [CI/CD Constitution](ci_cd_constitution.md)).
+
+**Done (to merge)**  
+- All required checks are green (see [Minimal CI (Week 1)](ci_minimal.md)).  
+- **Observability** markers considered (deploy marker, key metrics/events).  
+- **CHANGELOG** line is drafted (see [Commits & Changelog](commits_and_changelog.md)).  
+- Docs or flags updated as needed.
+
+---
+
+## 5) Conflict hygiene
+- Prefer updating your branch with `main` early (don’t sit on conflicts).  
+- Resolve conflicts locally; rerun **smoke** tests before flipping Ready.  
+- If a branch grows long-lived, split into micro-PRs and merge incrementally.
+
+---
+
+## 6) Hotfixes
+- Branch from the last production tag (e.g., `mvp-0.6.0`): `hotfix/short-slug`.  
+- Keep the PR tiny; tag a new patch (`mvp-0.6.1`); follow the [Release Playbook](../runbooks/release_playbook.md).  
+- Back-merge to `main` if you had to cut from an older tag.
+
+---
+
+## 7) Batching safely (umbrella PR)
+Use when a single user-facing feature needs several small PRs.
+
+Pattern:  
+- Create `feat/umbrella-tenancy-wizard` with a Draft summary and acceptance bullets.  
+- Link child PRs like `feat/tenant-wizard-form`, `feat/tenant-wizard-email`, `chore/db-indexes-wizard`.  
+- Merge children one by one behind **feature flags** ([Feature Flag](../reference/glossary.md#feature-flag)).  
+- Close the umbrella PR once staging passes a full **smoke** of the end-to-end flow.
+
+---
+
+## 8) GitHub settings (branch protection, solo-friendly)
+- Protect `main`: require status checks to pass.  
+- Enable “Require linear history” and “Require pull request before merging.”  
+- Allow only **squash-merge**. Disable rebase/merge commits.  
+- Optional (solo): don’t require code owners/reviews; rely on checks.
+
+See more principles in the [CI/CD Constitution](ci_cd_constitution.md).
+
+---
+
+## 9) FAQs
+**Q: When do I open a PR?**  
+As soon as you branch. Draft PRs create a social contract with your future self.
+
+**Q: How big is too big?**  
+If review takes more than ~15 minutes, split it.
+
+**Q: How do I handle database changes?**  
+Use **Expand → Migrate → Contract**; write idempotent scripts under `migrations/sql/` (e.g., `V003__add_tenant_id.sql`). Reference them in the **Migrations** section of the PR.
+
+**Q: Do I rebase?**  
+With squash-merge, either rebase or merge `main` into your branch—your final history will be a single squashed commit anyway.
+
+**Q: What goes in the squash title/body?**  
+Title: `type(scope): subject`. Body: **Because / Changed / Result** in 3–6 lines; link related Issues.
+
+---
+
+## 10) Pointers
+- Template: [.github/pull_request_template.md](../../.github/pull_request_template.md)  
+- Commits & Changelog: [docs/policy/commits_and_changelog.md](commits_and_changelog.md)  
+- Minimal CI: [docs/policy/ci_minimal.md](ci_minimal.md)  
+- CI/CD Constitution: [docs/policy/ci_cd_constitution.md](ci_cd_constitution.md)  
+- Glossary: [docs/reference/glossary.md](../reference/glossary.md)
+
+> Example filenames in this document are wrapped with backticks to avoid accidental links (e.g., `V003__add_tenant_id.sql`).

--- a/docs/policy/ci_cd_constitution.md
+++ b/docs/policy/ci_cd_constitution.md
@@ -1,0 +1,134 @@
+# CI/CD Constitution — Menu Optimizer MVP
+**Version:** 1.2 • **Updated:** 2025-09-19 14:42  
+**Applies to:** Streamlit app + Supabase Postgres (multi-tenant)
+
+Terms link to the [Glossary](../reference/glossary.md).
+
+---
+
+## North Star
+Ship **small, safe, reversible** changes on a steady cadence. Optimize for:  
+- short lead time,  
+- low change failure rate,  
+- fast MTTR (mean time to restore), and  
+- frequent deploys.
+
+We achieve this with **trunk-based development**, **automation with taste**, and **evidence over drama**.
+
+---
+
+## Branching & Flow
+- `main` is sacred and always releasable. (See [Branching & PR Protocol](branching_and_prs.md)).  
+- Short-lived branches (`feat/*`, `fix/*`, `chore/*`), opened as **Draft PRs** immediately.  
+- **Squash-merge** to `main`; delete branches after merge.  
+- Tags from `main`: `mvp-X.Y.Z` (see [Conventional Commits & Changelog](commits_and_changelog.md)).
+
+**MVP now:** trunk-only, Draft PRs, squash-merge.  
+**v1 later:** optional preview environments per PR; release candidate branches if needed.
+
+---
+
+## Required PR Checks (gates)
+1) **Style** — ruff + format (no nitpicking in review).  
+2) **Unit tests** — minutes, not hours.  
+3) **Thin smoke** — app boots; Golden Path works (non-destructive).
+
+**MVP now:** 1–3 above (see [Minimal CI](ci_minimal.md)).  
+**v1 later:** security scans, coverage thresholds, mutation tests.
+
+**Rule:** **flaky tests are an outage** — quarantine or fix within 48h.
+
+---
+
+## Build Once, Promote Many
+- Build a single **immutable artifact** per commit (container recommended).  
+- Inject **environment variables** at runtime (12-factor).  
+- Store provenance: commit SHA, build time, dependency digest in the artifact label.
+
+**MVP now:** artifact + staging deploy on merge to `main`.  
+**v1 later:** SBOM and signed artifacts.
+
+---
+
+## Environments (SimplerTree)
+- **Staging** — auto-deploy on merge to `main`; mirrors prod closely.  
+- **Production** — manual approval via **GitHub Environments**; feature flags default OFF.
+
+See details in [Environments & Secrets](env_and_secrets.md).
+
+---
+
+## Migrations (Expand → Migrate → Contract)
+- **Expand**: additive changes first (columns/tables), code reads both shapes.  
+- **Migrate**: backfill jobs; keep idempotent scripts in `migrations/sql/` (e.g., `V003__add_tenant_id.sql`).  
+- **Contract**: remove old structures only after a **staging burn-in** and telemetry shows safety.
+
+Document the plan in the PR (**Migrations** section).
+
+---
+
+## Idempotency & Events
+- Mutations accept an **idempotency key**; retries are safe.  
+- Events are **at-least-once**; dedupe by `correlation_id`.  
+- Include `version`, `tenant_id`, `request_id`, `correlation_id` in logs/events.
+
+Changes to events belong under **Changed** in the [CHANGELOG](../../CHANGELOG.md).
+
+---
+
+## Feature Flags & Rollout
+- **Merge early, release later**: hide unfinished paths behind flags.  
+- Each flag has: **owner**, **default**, **planned removal date**.  
+- Enable by **tenant cohort** first; observe metrics; then widen.
+
+In PRs, fill the **Flags** section (see the template at `../../.github/pull_request_template.md`).
+
+---
+
+## Observability
+- Add **deploy markers** with version/SHA.  
+- Log standard IDs (version/tenant/request/correlation).  
+- Keep an at-a-glance dashboard for: error rate, latency, success rate of the Golden Path.
+
+Post-deploy **smoke** runs automatically; failures block promotion.
+
+---
+
+## Rollback and Roll-forward
+- Prefer **rollback** to last healthy artifact on smoke failure or SLO breach.  
+- If the fix is trivial and safer than rollback, **roll-forward** quickly with a hotfix.
+
+Document the decision briefly in the release notes.
+
+---
+
+## Documentation & Roles
+- Every PR body uses **Because / Changed / Result / Done when / Out of scope / Flags / Migrations / Observability / Changelog**.  
+- Decisions that set precedent become **ADRs** (`docs/adr/`).  
+- Owners:  
+  - **CI/CD Constitution** — owner: Mathieu
+  - **Release Playbook** — owner: Mathieu
+  - **Environments & Secrets** — owner: Mathieu
+
+**Review cadence:** quick scan monthly; deeper audit each release.
+
+---
+
+## GitHub Actions (shape, not YAML)
+- **PR workflow**: checkout → setup Python → cache deps → style → unit → thin smoke → status.  
+- **Main merge workflow**: build artifact → push to registry → deploy to **staging** → run smoke.  
+- **Promotion**: manual approval in **production** environment → deploy same artifact → smoke.
+
+Secrets per environment are stored in **GitHub Environments** (see [Environments & Secrets](env_and_secrets.md)).
+
+---
+
+## Risk policy
+- Small PRs, reversible steps, and strong observability beat heroics.  
+- Breaking changes must use the `!` marker **and** a `BREAKING CHANGE:` footer, with migration steps and a rollback path (see [Glossary → Breaking Change](../reference/glossary.md#breaking-change)).
+
+---
+
+Sections labeled “MVP now” are in-scope immediately; “v1 later” items are parked until the React/Forge transition.
+
+**Examples of filenames are wrapped in backticks to avoid accidental links (e.g., `V003__add_tenant_id.sql`).**

--- a/docs/policy/ci_minimal.md
+++ b/docs/policy/ci_minimal.md
@@ -1,0 +1,106 @@
+# Minimal CI (Week 1)
+**Updated:** 2025-09-18 20:38
+
+Purpose: fast, deterministic feedback on every PR so you can merge small, safe changes without ritual. Terms link to the [Glossary](../reference/glossary.md).
+
+---
+
+## 1) What “Minimal” means
+- **Style gate**: ruff and formatter (black/isort) in check mode to keep reviews focused on intent.  
+- **Unit tests**: fast logic checks.  
+- **Thin smoke**: app boots and the **Golden Path** succeeds (non-destructive).
+
+That’s it for MVP. No heroics, no flaky E2E marathons.
+
+See also: [CI/CD Constitution](ci_cd_constitution.md), [Branching & PR Protocol](branching_and_prs.md).
+
+---
+
+## 2) Trigger model
+- **pull_request → main**: run style → unit → thin smoke; block merge if any fail.  
+- **push → main**: build the **artifact**, deploy to **staging**, then run the smoke again post-deploy. (See [Build Once, Promote Many](ci_cd_constitution.md#build-once-promote-many)).
+
+---
+
+## 3) Job breakdown (conceptual)
+**Job: check** (PRs)  
+- Checkout repository.  
+- Setup Python (pin to the project baseline).  
+- Restore dependency cache (keyed by lockfile hash).  
+- Install dev dependencies (`ruff`, `pytest`, etc.).  
+- Run ruff (lint) and ruff-format/black/isort in **check** mode.  
+- Run unit tests.  
+- Run thin smoke (non-destructive).  
+- Upload artifacts (logs, junit xml) on failure for quick triage.
+
+**Job: build-and-stage** (on merge to `main`)  
+- Build the immutable artifact (container recommended).  
+- Label artifact with version, commit SHA, and dependency digest.  
+- Push to your **artifact registry**.  
+- Deploy artifact to **staging** with environment-scoped secrets (see [Environments & Secrets](env_and_secrets.md)).  
+- Run post-deploy smoke; mark the deploy with a **deploy marker**.
+
+**Job: promote-prod** (manual)  
+- Manual approval via GitHub **production** environment.  
+- Deploy the **same** artifact used in staging.  
+- Run smoke again; if it fails, **rollback**.
+
+---
+
+## 4) What to test (Week 1 scope)
+- **Unit**: pure functions and adapters (db helpers, parsers, simple services).  
+- **Integration**: only where contracts are brittle (db layer, auth handshake). Keep it fast.  
+- **Smoke**: one Golden Path for the core user journey.
+
+If a test flakes: treat it as an **outage**—quarantine or fix within 48h (see [CI/CD Constitution](ci_cd_constitution.md#required-pr-checks-gates)).
+
+---
+
+## 5) Caching & speed
+- Cache Python dependencies by **lockfile hash**.  
+- Avoid network calls in tests; mock or use tiny fixtures.  
+- Keep the smoke minimal (one or two assertions).  
+- Fail fast; don’t run slower jobs after a hard failure when on PRs.
+
+---
+
+## 6) Secrets & environments
+Use **GitHub Environments** to store per-env secrets (e.g., `staging` and `production`).  
+Populate only the keys needed (SUPABASE_URL, SUPABASE_ANON_KEY, SERVICE_ROLE, etc.).  
+Never echo secrets in logs; prefer masked outputs.
+
+See: [Environments & Secrets](env_and_secrets.md).
+
+---
+
+## 7) Status checks & branch protection
+- Protect `main`.  
+- Require the **check** job to pass before merging.  
+- Enforce **linear history** and “Require a pull request before merging”.  
+- Allow only **squash-merge**.
+
+See: [Branching & PR Protocol](branching_and_prs.md#8-github-settings-branch-protection-solo-friendly).
+
+---
+
+## 8) Failure playbook (CI)
+- **Style fails**: run the formatter locally; commit.  
+- **Unit fails**: fix or xfail; if flaky, quarantine.  
+- **Smoke fails on PR**: investigate locally; do not merge.  
+- **Smoke fails after staging deploy**: rollback (if needed) or fix forward; document briefly in release notes.
+
+For production, follow the [Release Playbook](../runbooks/release_playbook.md).
+
+---
+
+## 9) What’s next (v1 later)
+- Security scans and dependency audit.  
+- Coverage reporting with a pragmatic threshold (avoid chasing 100%).  
+- **Preview environments** per PR for richer review.  
+- **SBOM** generation and artifact signing.
+
+These can wait until after MVP.
+
+---
+
+> Example filenames in this document are wrapped in backticks to avoid accidental links (e.g., `V003__add_tenant_id.sql`).

--- a/docs/policy/commits_and_changelog.md
+++ b/docs/policy/commits_and_changelog.md
@@ -1,0 +1,142 @@
+# Conventional Commits & Changelog Rules
+**Updated:** 2025-09-18 19:42
+
+Purpose: keep history **explanatory**, releases **human-readable**, and changes **classifiable**. Terms link to the [Glossary](../reference/glossary.md).
+
+> Canonical note: this page is the **source of truth** for commit intent. It refines and supersedes the quick tree summarized in [Docs Policy & Map](docs_policy.md).
+
+---
+
+## 1) Commit anatomy
+Format: `type(scope): subject`  
+
+- **type** — intent (see decision tree below).  
+- **scope** — optional focus area (e.g., `intake`, `identity`, `measure`, `chronicle`, `lexicon`, `ui`, `db`, `ci`, `docs`, `release`, `scripts`).  
+- **subject** — imperative mood, no ending period, ≤ 72 chars.
+
+Body (optional but encouraged): 3–6 lines answering **Because / Changed / Result**.  
+Footers (optional): `Closes #123`, `Refs #456`, `BREAKING CHANGE: ...`, `Co-authored-by: ...`
+
+> Squash merges: title should be a Conventional Commit; copy the **Because / Changed / Result** summary into the body. See [Branching & PR Protocol](branching_and_prs.md).
+
+---
+
+## 2) Commit intent decision tree (refined)
+Use this tree to pick a **single** intent. If you did two distinct things, make two commits.
+
+1) **Did runtime behavior visible to users change?**  
+   - **Yes → Is it new behavior?**  
+     - **Yes → `feat`** — e.g., `feat(intake): bulk import of recipes`  
+     - **No  → `fix`**  — e.g., `fix(lexicon): prevent duplicate UOMs`
+   - **No → Continue:**
+
+2) **Did performance improve without changing behavior?**  
+   - **Yes → `perf`** — e.g., `perf(db): add index on tenant_id`  
+   - **No → Continue:**
+
+3) **Is this an internal code change with no behavior change?**  
+   - **Yes → `refactor`** — e.g., `refactor(chronicle): extract event writer`  
+   - **No → Continue:**
+
+4) **Is this documentation-only?**  
+   - **Yes → `docs`** — e.g., `docs(ci): add smoke checklist`  
+   - **No → Continue:**
+
+5) **Is this test-only?**  
+   - **Yes → `test`** — e.g., `test(utils): add idempotency tests`  
+   - **No → Continue:**
+
+6) **Is this build/package config or CI workflow?**  
+   - **Yes → `build`** (packaging), or **`ci`** (workflows)  
+     - e.g., `ci: add ruff and smoke job`  
+     - e.g., `build: pin streamlit to 1.39`  
+   - **No → Continue:**
+
+7) **Is this dependency, config, or repo housekeeping?**  
+   - **Yes → `chore`** — e.g., `chore: bump ruff to 0.6.2`  
+   - **No → Continue:**
+
+8) **Is this formatting-only or lints-only change (no logic)?**  
+   - **Yes → `style`** — e.g., `style: ruff --fix across utils`  
+   - **No → Continue:**
+
+9) **Are you reverting a prior commit?**  
+   - **Yes → `revert`** — include the SHA and reason
+
+> Breaking changes: use the `!` shorthand in the type (e.g., `feat!:`) **and** add a `BREAKING CHANGE:` footer. Pre-1.0, treat breaking changes as **minor** bumps (Y). See [Glossary → SemVer](../reference/glossary.md#semver-semantic-versioning).
+
+---
+
+## 3) Good subject lines
+- Do: “normalize”, “add”, “remove”, “migrate”, “guard”, “emit”.  
+- Avoid: “address review comments”, “wip”, “misc fixes”.  
+- Keep it human; assume a future you scanning 6 months from now.
+
+**Examples**  
+- `feat(identity): support Google OAuth login`  
+- `fix(intake): clamp negative quantities`  
+- `refactor(db): isolate RLS helpers`  
+- `perf(ingredients): cache costing for 10x speedup`  
+- `ci: run thin smoke on PRs`  
+- `docs(policy): clarify decision tree`
+
+---
+
+## 4) Scopes (house style)
+Pick a short noun; avoid nesting. Common scopes: `intake`, `identity`, `measure`, `chronicle`, `lexicon`, `ui`, `db`, `ci`, `docs`, `release`, `scripts`.  
+If you must touch multiple areas, keep the scope generic (`ui`, `db`) and explain details in the body.
+
+---
+
+## 5) Changelog rules (human first)
+We follow **Keep a Changelog** so humans can skim releases.
+
+**Sections we use**
+- **Added** — new features (primarily `feat`)  
+- **Changed** — behavior changes, migrations, large refactors with user impact  
+- **Fixed** — bug fixes (`fix`)  
+- **Removed** — deprecations or feature removals  
+- **Security** — security-impacting changes
+
+**Curation beats automation**: the PR author proposes a one-liner under **Changelog** in the PR template; the release editor polishes it.
+
+**Mapping (guidance, not law)**
+- `feat` → **Added**  
+- `fix` → **Fixed**  
+- `perf`/`refactor` with user impact → **Changed** (otherwise omit)  
+- `docs`, `test`, `style`, `chore`, `ci`, `build` → usually omitted unless noteworthy (then **Changed**)
+
+> Scripts in use: `gen_changelog.py` and `release_notes.sh`. See the [Release Playbook](../runbooks/release_playbook.md) for when to run them.
+
+---
+
+## 6) Versions & tags
+- Single source of truth: the `VERSION` file (displayed in-app).  
+- Tags from `main`: `mvp-X.Y.Z`. Pre-1.0: bump **Y** for features (and breaking changes), **Z** for fixes.  
+- Releases are built once and promoted; see [CI/CD Constitution](ci_cd_constitution.md).
+
+---
+
+## 7) FAQ
+**Q: I touched docs and code in the same commit—what type?**  
+Prefer two commits. If you must squash: choose the **dominant** intent and mention the secondary work in the body.
+
+**Q: I renamed files and changed behavior—`style` or `feat`?**  
+Behavior wins: use `feat` or `fix`. Mention the rename in the body.
+
+**Q: Do I need a scope?**  
+No, but it helps searchability and changelog clarity.
+
+**Q: Are long bodies okay?**  
+Yes if they explain decisions (link Issues/ADRs). Keep the subject tight.
+
+---
+
+## 8) Quick reference
+- Format: `type(scope): subject`  
+- One intent per commit; split if needed.  
+- Use backticks for example filenames in docs (e.g., `V003__add_tenant_id.sql`).  
+- Draft PR early; copy **Because / Changed / Result** into the squash body.  
+- Update the PR’s **Changelog** line; the release editor curates final notes.
+
+See also: [Branching & PR Protocol](branching_and_prs.md), [Minimal CI (Week 1)](ci_minimal.md), [CI/CD Constitution](ci_cd_constitution.md), and the [Glossary](../reference/glossary.md).

--- a/docs/policy/docs_policy.md
+++ b/docs/policy/docs_policy.md
@@ -1,0 +1,141 @@
+# Docs Policy & Map
+**Updated:** 2025-09-18 19:19
+
+This page defines *what goes where*, how docs evolve, and how to keep knowledge tidy without slowing down delivery.  
+Need a definition? See the [Glossary](../reference/glossary.md).
+
+---
+
+## 1) The Three Homes
+We separate knowledge by *how durable it needs to be*.
+
+**Library (Repo: `docs/…`)** — durable truths that travel with the code.  
+**Town Square (GitHub)** — living plans, debates, status (Issues/Projects/PRs/Discussions).  
+**Archive (OneDrive)** — heavy or long-form artifacts (docx, decks, screenshots, customer notes).
+
+Why: the repo’s history shouldn’t churn every time a checklist item flips from unchecked to checked.
+
+---
+
+## 2) What lives where (authoritative)
+**Repo (`docs/`)**
+- **Policy** (rules we run by): `docs/policy/`
+  - CI/CD Constitution → `docs/policy/ci_cd_constitution.md`
+  - Branching & PR Protocol → `docs/policy/branching_and_prs.md`
+  - Conventional Commits & Changelog → `docs/policy/commits_and_changelog.md`
+  - Minimal CI (Week 1) → `docs/policy/ci_minimal.md`
+  - Environments & Secrets → `docs/policy/env_and_secrets.md`
+  - This page → `docs/policy/docs_policy.md`
+- **Runbooks** (how-tos used under stress): `docs/runbooks/`
+  - Release Playbook → `docs/runbooks/release_playbook.md`
+  - First-Run (Phase 1) and Rollback (Phase 2) will live here too.
+- **Reference** (contracts the code depends on): `docs/reference/`
+  - Glossary → `docs/reference/glossary.md`
+  - Data Dictionary (add later)
+  - Events & Error Model (Phase 3)
+- **Specs** (accepted / contractual): `docs/specs/`
+  - Index arrives in Phase 1.
+- **ADRs** (Architecture Decision Records): `docs/adr/`
+  - Template arrives in Phase 2.
+- **Archive (lightweight)**: `docs/archive/`
+  - Index files that *link out* to OneDrive for large packs.
+
+**GitHub**
+- **Issues** — work items, checklists, follow-ups.  
+- **Projects** — planning/priority boards.  
+- **Pull Requests** — proposals and reviews (start as Draft).  
+- **Discussions** — brainstorms and Q&A (optional).
+
+**OneDrive**
+- Meeting notes, customer research, Chef feedback, large screenshots, videos, decks.  
+- Organize by date and topic; keep a link index from `docs/archive/INDEX.md`.
+
+---
+
+## 3) File/Folder conventions
+- Kebab-case names; **no spaces**. Example: 'data-dictionary.md'.  
+- Use a date prefix when chronology matters. Example: '2025-08-19-tenant-interview-notes.md'.  
+- Recommended layout (see the Project Bible at [docs/README.md](../README.md) for the full map).
+
+**Docs maturity badges (top of each doc):** `[Draft]`, `[Accepted]`, `[Superseded by 'ADR-0005-…']`.
+
+---
+
+## 4) Writing rules (style that scales)
+- Write for *future you*: lead with *why*, then *what*, keep *how* crisp.  
+- Use short, skimmable sections; prefer lists over walls of text.  
+- When showing filenames, **quote them** so they don’t auto-link (e.g., '2025-08-19-title.md').  
+- Link terms to the [Glossary](../reference/glossary.md) the first time they appear (e.g., [CI](../reference/glossary.md#ci-continuous-integration), [ADR](../reference/glossary.md#adr-architecture-decision-record), [SemVer](../reference/glossary.md#semver-semantic-versioning)).
+
+---
+
+## 5) Change process (lightweight governance)
+- **Small edits** → normal PR. Use the intent-first template.  
+- **Major rewrites** → start a Draft PR labeled `docs:` with a 3–5 bullet summary (why, scope, impact).  
+- **Policy changes** (anything under `docs/policy/`) → require reviewer acknowledgement before merge.  
+- **Superseding** → keep the old doc, add a banner at top: “Superseded by 'ADR-####-…' or 'rfc-####-…'” and link the replacement.
+
+**Commit intent decision tree (pointer)** — canonical lives in [Conventional Commits & Changelog](commits_and_changelog.md). Quick-skim version:
+
+1) Runtime behavior visible to users changed?  
+   • Yes → new behavior → **feat**. Bug fix → **fix**.  
+   • No  → continue.
+
+2) Performance improved with no behavior change? → **perf**.  
+3) Internal code-only change (no behavior change)? → **refactor**.  
+4) Documentation-only? → **docs**. Tests-only? → **test**.  
+5) Build packaging vs CI workflows? → **build** / **ci**.  
+6) Dependencies/config/repo housekeeping? → **chore**.  
+7) Formatting-only (no logic)? → **style**.  
+8) Reverting a prior commit? → **revert**.
+
+Breaking changes: use `!` in the type (e.g., `feat!:`) **and** add a `BREAKING CHANGE:` footer.
+See: [Commits & Changelog](commits_and_changelog.md).
+
+---
+
+## 6) Linking rules (so links don’t rot)
+- Prefer **relative links** inside the repo (e.g., `../policy/ci_cd_constitution.md`).  
+- For GitHub Issues/PRs, paste the canonical URL; for OneDrive, paste the shared link and add a short label.  
+- Do not link to **mutable** Google Docs as truth—export or summarize key decisions into the repo (or create an ADR).
+
+---
+
+## 7) Trackers and specs (Library ↔ Town Square handshake)
+- Trackers and checklists **live in GitHub Issues/Projects** (not the repo).  
+- Specs are drafted in Discussions or OneDrive; once **accepted**, create an RFC/Spec in `docs/specs/` and link the originating Discussion/Issue.  
+- Each Spec has: *Intent*, *Decision*, *Constraints*, *Impact*, *Open Questions*, *Owner*, *Reviewers*.  
+- When a Spec changes runtime behavior, ensure the PR uses the intent-first template and update the [CHANGELOG](../../CHANGELOG.md).
+
+---
+
+## 8) Security & privacy for docs
+- Never commit secrets or keys (see [Environments & Secrets](env_and_secrets.md)).  
+- Do not copy raw customer data into the repo. For examples, anonymize and store any real samples in OneDrive.  
+- Avoid personal data in Issues/PRs; put sensitive details in OneDrive and link with a redacted summary.
+
+---
+
+## 9) Ownership & lifecycle
+- Every **Policy** page lists an **Owner** at top; the owner tends the garden and drives updates.  
+- **Review cadence:** quick scan monthly; deeper review each release.  
+- **Archival:** when a document stops being useful, move it under `docs/archive/` and link its replacement.
+
+---
+
+## 10) Indexes you can trust
+- The Project Bible at [docs/README.md](../README.md) is the canonical index.  
+- Add new docs there as they appear; if it’s not on the map, it doesn’t exist.
+
+---
+
+### Appendix A — Directory quick map
+- `docs/policy/` — constitutions, protocols, governance (e.g., 'ci_cd_constitution.md').  
+- `docs/runbooks/` — pressure-tested how-tos (e.g., 'release_playbook.md').  
+- `docs/reference/` — canonical facts (e.g., 'glossary.md', later data dictionary).  
+- `docs/specs/` — accepted specs and RFCs (index added in Phase 1).  
+- `docs/adr/` — small, dated decisions (template ships in Phase 2).  
+- `docs/archive/` — small stubs that link out to large OneDrive packs.
+
+When in doubt, ask: **Will future code or decisions break if this knowledge goes missing?**  
+If yes → it belongs in the **Library**. If no → Town Square or Archive.

--- a/docs/policy/env_and_secrets.md
+++ b/docs/policy/env_and_secrets.md
@@ -1,0 +1,111 @@
+# Environments & Secrets (SimplerTree)
+**Updated:** 2025-09-19 13:11
+
+Goal: keep you shipping with **staging → production**, clean separation of data, and zero leaked secrets. Terms link to the [Glossary](../reference/glossary.md).
+
+---
+
+## 1) The SimplerTree
+- **Staging** — auto-deploy on merge to `main`; mirrors prod closely; scrubbed data; safe for UAT.  
+- **Production** — manual approval; live users; feature flags default **OFF**.
+
+**Out-of-scope for MVP** (parked for v1): per-PR preview environments; blue/green; canary at the infra level (we emulate canary via **feature flags**). See: [CI/CD Constitution](ci_cd_constitution.md).
+
+---
+
+## 2) Source of truth for configuration
+- **Runtime config via environment variables** (12-factor). No env-specific builds.  
+- Repo only contains **templates**, never real secrets:
+  - `.env.example` — sample local variables (no credentials).  
+  - `.streamlit/secrets.toml.example` — sample Streamlit secrets.  
+- Real secrets live in **GitHub Environments**:
+  - `staging` — scoped secrets for staging.
+  - `production` — scoped secrets for production.
+
+See also: [Minimal CI (Week 1)](ci_minimal.md) and [Release Playbook](../runbooks/release_playbook.md).
+
+---
+
+## 3) Environment variables (MVP list)
+Name → purpose (and whether secret):  
+- `APP_ENV` → `staging` or `production` (not secret).  
+- `APP_VERSION` → injected from `VERSION`/tag (not secret).  
+- `SUPABASE_URL` → project URL (treat with care; not a secret but avoid leaking).  
+- `SUPABASE_ANON_KEY` → public client key (handle carefully; not admin).  
+- `SUPABASE_SERVICE_KEY` → service role key (secret; **never** ship to browser).  
+- `SUPABASE_SCHEMA` → primary schema name if non-default (not secret).  
+- `SENTRY_DSN` (or equivalent) → error reporting (secret).  
+- `LOG_LEVEL` → `INFO`/`DEBUG` (not secret).  
+- `FEATURE_FLAGS_JSON` → optional JSON for defaults (not secret).
+
+If you add more, update this list and the templates.
+
+---
+
+## 4) Secrets handling in GitHub
+- Define **Environments** named `staging` and `production`.  
+- Add secrets with identical **keys** across envs; values differ per env.  
+- Use protection rules: require approval to deploy to `production`.  
+- Jobs reference them as environment-scoped secrets (never echo values).
+
+**Rotation policy**  
+- Rotate immediately if a secret is suspected exposed.  
+- Routine rotation every 90–180 days for service keys.
+
+---
+
+## 5) Data policy
+- **Staging** uses **scrubbed or synthetic** data; avoid copying raw prod.  
+- Access to `production` DB is least-privilege; prefer read-only replicas for analytics.  
+- Keep only **release** schema dumps in `schema/` (e.g., `supabase_schema_2025-09-16_01.sql`). Add non-release dumps to `.gitignore`.
+
+---
+
+## 6) Feature flags (runtime safety)
+- Merge early, release later. Flags let you ship code dark and enable per **tenant cohort**.  
+- Each flag defines **owner**, **default**, **planned removal date**.  
+- Kill switch must exist. Document flags in the PR (see the template at `../../.github/pull_request_template.md`).
+
+See: [Glossary → Feature Flag](../reference/glossary.md#feature-flag).
+
+---
+
+## 7) Observability & deploy markers
+- Include `version`, `tenant_id`, `request_id`, and `correlation_id` in logs/events.  
+- Add a **deploy marker** on staging and prod so you can correlate behavior with deploys.  
+- Run post-deploy **smoke**; if it fails, rollback or fix forward. See: [CI/CD Constitution](ci_cd_constitution.md#rollback-and-roll-forward).
+
+---
+
+## 8) Access & roles (Supabase specifics)
+- Client uses **Anonymous Key** with **RLS** (Row-Level Security) enforced.  
+- Server-side operations use **Service Role** key from the environment (never shipped to browser).  
+- Periodically audit policies to ensure no cross-tenant reads/writes.
+
+---
+
+## 9) Naming & branching conventions (env sense)
+- Branch names do not encode environments. The **artifact** is the same for staging and prod.  
+- Use tags like `mvp-0.6.0` to identify the artifact; inject `APP_VERSION` from the tag.
+
+---
+
+## 10) Setup checklist (MVP — do once)
+- Create GitHub **Environments**: `staging`, `production`.  
+- Add secrets in each: `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_KEY`, `SENTRY_DSN` (optional), and any others you use.  
+- Commit `.env.example` and `.streamlit/secrets.toml.example` with placeholder values.  
+- Ensure CI workflow deploys to **staging** on merge to `main` and requires approval for **production**.  
+- Add post-deploy **smoke** in both environments.  
+- Document any **flags** added in PRs; maintain an index under `docs/reference/` (Phase 2).
+
+---
+
+## 11) v1 enhancements (parked)
+- **Preview environments** per PR.  
+- **Blue/green** at infra level.  
+- Centralized **secret management** (e.g., Vault) with auto-rotation.  
+- **SBOM** and signed artifacts for supply-chain integrity.
+
+---
+
+> Example filenames in this document are wrapped with backticks to avoid accidental links (e.g., `supabase_schema_2025-09-16_01.sql`).

--- a/docs/policy/specs_workflow.md
+++ b/docs/policy/specs_workflow.md
@@ -1,0 +1,116 @@
+# Specs Workflow & Acceptance (MVP)
+**Updated:** 2025-09-19 18:25
+
+Purpose: a light-but-real path for specifications to move from idea to **Accepted (MVP)** without bloating your day. Terms link to the [Glossary](../reference/glossary.md).
+
+Related: [Docs Policy & Map](docs_policy.md), [Branching & PR Protocol](branching_and_prs.md), [CI/CD Constitution](ci_cd_constitution.md), [Commits & Changelog](commits_and_changelog.md), [Environments & Secrets](env_and_secrets.md), [GitHub Projects setup](../runbooks/github_projects_setup.md).
+
+---
+
+## 1) Where specs live (and where they don’t)
+- **Main branch is canonical**: `docs/specs/` on **main** contains **only Approved (Accepted) specs**.
+- **Drafts live only in PR branches**: create/edit the spec in a `spec/<short-slug>` branch under the same path (`docs/specs/…`) so the folder structure stays consistent, but it doesn’t land in main until approved.
+- **Town Square**: GitHub **Issues/Projects** track status and discussion; link PRs there.
+- **Archive/heavy packs**: OneDrive (research dumps, giant screenshots).
+
+*Optional later*: if you prefer drafts visible in-repo, use `docs/proposals/` for drafts and move to `docs/specs/` on acceptance. For MVP we keep main clean.
+
+---
+
+## 2) Status model (Project → Spec lifecycle)
+Use the **Status** field from the Project. Suggested flow:
+
+- **Draft** — spec exists but needs acceptance bullets/problem framing.  
+- **In review** — Draft PR and review comments flowing.  
+- **Accepted** — approved for MVP scope; ready to break into feature work.  
+- **Parked** — intentionally paused; add a “revisit by” note.  
+- **Superseded** *(optional)* — replaced by a newer spec; link both ways.
+
+Only **Accepted** specs represent current MVP scope.
+
+**Project note**: add **Superseded** as a Status (neutral color) if you want that explicit state; otherwise leave items Parked and note “superseded by …” in the body.
+
+---
+
+## 3) Authoring a spec (minimum viable content)
+Create a branch and a file (in that branch) named like `NN_Module_MVP_Spec.md` or `YYYY-MM-DD-short-slug.md` under `docs/specs/`. Include:
+
+- **Problem** — the user/tenant pain and why it matters now.  
+- **Goals / Non-goals** — bullets.  
+- **Users & tenants impacted** — who touches this.  
+- **Happy path scenarios** — a couple of realistic flows.  
+- **Out of scope** — bullets to prevent scope creep.  
+- **Risks & assumptions** — what could bite us; what we’re betting on.  
+- **Migrations** — database shape changes (follow **Expand → Migrate → Contract**).  
+- **Feature flags** — owner, default, kill switch, removal date.  
+- **Observability** — events/metrics to watch after release; deploy marker name.  
+- **Acceptance bullets** — the merge-ready checklist we will validate in PR.  
+- **Rollout** — staging → prod promotion plan (gates, soak window).  
+- **Dependencies** — upstream/downstream pieces.  
+- **Open questions** — things we deliberately leave to discovery.
+
+Keep prose tight. Specs are decision amplifiers, not novels.
+
+---
+
+## 4) Intake & review (lightweight, MVP)
+1) **Branch**: create `spec/<short-slug>` from `main`.  
+2) **Spec file**: add/edit under `docs/specs/` in that branch. Commit with `docs(specs): draft <short-title>`.  
+3) **Draft PR**: open from `spec/<short-slug>`; title `spec: <short-title>`.  
+4) **Spec Review Issue**: use `.github/ISSUE_TEMPLATE/spec_review.md` and fill **Because**, **Doc link**, **Acceptance bullets**, **Flags**, **Migrations**, **Observability**.  
+5) **Project fields**: add the Issue to the Project → `Type = Spec`, `Status = Draft`, fill **Doc Link** (use the PR URL or the branch file URL), then when ready set `Status = In review` and fill **PR Link**.  
+6) Iterate in the PR; aim for clarity, safety, and testability—not perfection.
+
+---
+
+## 5) Acceptance criteria (when to flip to Accepted)
+A spec becomes **Accepted** when:
+- Acceptance bullets are precise and testable.  
+- Risk is understood and bounded (flags/rollback exist where needed).  
+- Migrations are safe (idempotent scripts, burn-in plan).  
+- Observability plan exists (what smoke/metrics we’ll check).  
+- Out of scope is explicit to control creep.
+
+On approval:
+- **Squash-merge** the `spec/<short-slug>` PR into **main** (now the file exists in `docs/specs/` on main).  
+- Add a small header line at the top: `Status: Accepted (MVP) — YYYY-MM-DD`.  
+- Update the Project item to **Accepted**.
+
+---
+
+## 6) After acceptance → delivery
+- Break the spec into **Issues** (Feature/Bug/Chore) and link them back to the spec.  
+- Reference the spec in PRs implementing it.  
+- Use the [Release Playbook](../runbooks/release_playbook.md) for promotion.  
+- If the spec drives DB work, follow **Expand → Migrate → Contract** from the [CI/CD Constitution](ci_cd_constitution.md).
+
+---
+
+## 7) Change control
+- **Minor clarifications**: simple PR edits to the spec on main.  
+- **Material change** (scope/behavior): new PR from a branch (e.g., `spec/<slug>-v2`) and tag with `feat!` or include a `BREAKING CHANGE:` footer if contracts move.  
+- If an Accepted spec is later replaced, mark it **Superseded** with a link to the replacement and optionally move to `docs/archive/`.
+
+---
+
+## 8) Quick checklist (copy/paste)
+- [ ] Branch `spec/<short-slug>` from main  
+- [ ] Spec file created/updated under `docs/specs/` (in branch)  
+- [ ] Draft PR opened; Spec Review Issue created  
+- [ ] Project fields set: Type/Status/Links  
+- [ ] Acceptance bullets clear and testable  
+- [ ] Flags: owner, default, removal date, kill switch  
+- [ ] Migrations: **Expand → Migrate → Contract** plan  
+- [ ] Observability: smoke + metrics named  
+- [ ] On approval: squash-merge; mark file `Status: Accepted (MVP)`; Project → Accepted
+
+---
+
+## 9) Commit & PR hygiene for specs
+- Use `docs(specs): …` for pure spec edits.  
+- The PR body uses the template sections (**Because / Changed / Result / Done when / Out of scope / Flags / Migrations / Observability / Changelog**).  
+- For code work spawned by the spec, follow the [commit decision tree](commits_and_changelog.md#commit-intent-decision-tree).
+
+---
+
+> Example filenames in this policy are wrapped with backticks to avoid accidental links (e.g., `docs/specs/04_Intake_MVP_Specs.md`).

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -1,5 +1,5 @@
 # Glossary
-**Updated:** 2025-09-18 20:03
+**Updated:** 2025-09-19 15:18
 
 Shared definitions for CI/CD, Git/GitHub, Supabase, and our house style.  
 When in doubt, link terms here from any doc or PR.
@@ -18,8 +18,14 @@ A manual control (e.g., “Require review to deploy to production”). In GitHub
 ### Artifact (Immutable Artifact)
 The build output you deploy (e.g., container image). Built once per commit; the **same** artifact is promoted to staging then production. See: [CI/CD Constitution](../policy/ci_cd_constitution.md).
 
+### Artifact Provenance (Labels)
+Metadata embedded in the artifact that records version, commit SHA, build time, and dependency digest so you can trace exactly what’s running. See: [CI/CD Constitution](../policy/ci_cd_constitution.md).
+
 ### Artifact Registry
 A repository that stores built artifacts (e.g., container registry). Critical for “build once, promote many.”
+
+### At-least-once (Event Delivery)
+Delivery guarantee for events/logs where messages may be delivered more than once. Deduplicate downstream using a stable `correlation_id`. See: [CI/CD Constitution](../policy/ci_cd_constitution.md).
 
 ### Backfill
 A data migration step that populates or transforms existing rows to satisfy a new schema. Part of **Expand → Migrate → Contract**.
@@ -32,6 +38,9 @@ A top-level PR that coordinates several small, related PRs (the “micro-PRs”)
 
 ### Blue/Green Deployment
 Two production environments (“blue” live, “green” idle). You deploy to green, switch traffic, and keep blue as rollback. We generally prefer **canary** for MVP.
+
+### Build Once, Promote Many
+Build a single immutable artifact per commit and deploy the same artifact to each environment (staging → production) without rebuilding. Ensures what you tested is exactly what you run. See: [CI/CD Constitution](../policy/ci_cd_constitution.md).
 
 ### Build vs CI (Commit Types)
 **build**: build system or packaging changes. **ci**: continuous integration workflows or configuration changes. See: [Commits & Changelog](../policy/commits_and_changelog.md).
@@ -73,8 +82,17 @@ A canonical list of entities, columns, and enumerations the app depends on. Live
 ### Decision Tree (Commit Intent)
 Quick classifier for commits (feat, fix, docs, test, build, ci, style, refactor, chore, perf, revert). Canonical version lives in [Conventional Commits & Changelog](../policy/commits_and_changelog.md).
 
+### Definition of Ready (DoR)
+Local checklist for when a Draft PR is ready for review: scope is tight, acceptance bullets are testable, rollback exists, migrations planned if needed. See: [Branching & PR Protocol](../policy/branching_and_prs.md#4-definition-of-ready--done).
+
+### Definition of Done (DoD)
+Checklist for merge: required checks are green, observability markers considered, CHANGELOG line drafted, docs/flags updated. See: [Branching & PR Protocol](../policy/branching_and_prs.md#4-definition-of-ready--done).
+
 ### Deploy Marker
 A visible marker (with version/SHA) on dashboards/logs so deploys correlate with metrics. See: [CI/CD Constitution](../policy/ci_cd_constitution.md).
+
+### DORA Metrics
+Industry-standard delivery outcomes we care about: **Deployment Frequency**, **Lead Time for Changes**, **Change Failure Rate**, and **MTTR** (Mean Time to Restore). Our North Star for CI/CD. See: [CI/CD Constitution](../policy/ci_cd_constitution.md#north-star).
 
 ### Draft PR
 A pull request opened intentionally before it’s ready to merge so scope and acceptance can be reviewed while work is in progress. See: [Branching & PR Protocol](../policy/branching_and_prs.md).
@@ -118,11 +136,23 @@ Validates the contract between modules (e.g., DB layer + service). Sits between 
 ### Issue / Project (GitHub)
 **Issues** track work items; **Projects** group and prioritize them. We keep trackers here, not in git history. See: [Docs Policy & Map](../policy/docs_policy.md).
 
+### JUnit XML
+A common test report format that CI uploads on failure to speed up triage. Mentioned in our Minimal CI. See: [Minimal CI (Week 1)](../policy/ci_minimal.md).
+
+### Kebab-case (Naming)
+Lowercase words separated by hyphens used for file and branch names (e.g., `feat/add-tenant-wizard`). Improves portability and link reliability.
+
 ### Keep a Changelog
 Community format for writing CHANGELOG.md so humans can scan what changed. See: [Commits & Changelog](../policy/commits_and_changelog.md).
 
+### Kill Switch (Feature Flags)
+A flag or config that can immediately disable a risky path at runtime without redeploying. Every flagged feature should define a kill switch. See: [Environments & Secrets](../policy/env_and_secrets.md).
+
 ### Linear History
 A repository setting that enforces merges as single commits (squash) to avoid complex graph histories.
+
+### Lockfile / Cache Key
+The lockfile (e.g., pinned requirements) provides a stable hash used as a CI cache key for dependencies, keeping builds fast and deterministic. See: [Minimal CI (Week 1)](../policy/ci_minimal.md).
 
 ### Main (Trunk)
 The protected, always-releasable branch. All feature branches merge here via PR. See: [Branching & PR Protocol](../policy/branching_and_prs.md).
@@ -148,6 +178,9 @@ A proposal to merge changes. For us, PRs start as Draft, declare intent, and inc
 ### Preview Environment
 An ephemeral, per-PR deployment to click around safely. Useful in v1; out-of-scope for MVP.
 
+### Pre-commit / Ruff / Black / Isort
+Local tooling that runs before commits to keep style noise out of reviews. **pre-commit** runs hooks, **ruff** lints, **black** formats, **isort** orders imports. See: [Minimal CI (Week 1)](../policy/ci_minimal.md).
+
 ### Production
 The live environment for users. Access is least privilege; deploys require approval.
 
@@ -171,6 +204,9 @@ Fix forward with a new commit and redeploy, instead of rolling back.
 
 ### Rollback
 Returning the system to a previous healthy artifact or turning a flag off. Prefer rollback over hot-fixing in production.
+
+### Runbook
+A pressure-tested, step-by-step guide used during operations or incidents (e.g., `release_playbook.md`). Lives under `docs/runbooks/`.
 
 ### SBOM (Software Bill of Materials)
 A manifest of components and versions in your artifact. Useful for security and compliance; v1 item.
@@ -199,6 +235,9 @@ Merging a PR as a single commit to keep history clean. See: [Branching & PR Prot
 ### Staging
 Pre-production environment that mirrors prod closely. Auto-deploy on merge to main for rehearsal.
 
+### Staging Burn-in
+A period where new schema or behavior runs in staging while telemetry is monitored before contracting or promoting. See: [CI/CD Constitution](../policy/ci_cd_constitution.md#migrations-expand--migrate--contract).
+
 ### Tag (Git)
 A named pointer to a commit, often used for releases. Immutable by convention.
 
@@ -207,6 +246,9 @@ An isolated customer/account space. All data and actions are scoped by `tenant_i
 
 ### Test Pyramid
 Emphasis on many fast unit tests, fewer integration tests, and very few E2E tests.
+
+### Three Homes (Library / Town Square / Archive)
+Our documentation homes by durability: **Library** (repo `docs/` for durable truths), **Town Square** (GitHub for work-in-progress planning and review), **Archive** (OneDrive for heavy packs and research). See: [Docs Policy & Map](../policy/docs_policy.md#1-the-three-homes).
 
 ### Trunk-Based Development
 Working on short-lived branches that frequently merge into `main` (the trunk). See: [Branching & PR Protocol](../policy/branching_and_prs.md).
@@ -225,6 +267,9 @@ The single source of truth for the app’s version, displayed in-app and used fo
 
 ### Version Pinning
 Locking a dependency to a specific version to avoid surprise changes.
+
+### xfail (Expected Failure)
+A test marked as “expected to fail” when a known issue exists; keep usage rare and temporary. Mentioned in the CI failure playbook. See: [Minimal CI (Week 1)](../policy/ci_minimal.md).
 
 ### Zero-Downtime Migration
 Schema/data evolution done without taking the app offline, usually via **Expand → Migrate → Contract**.

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -1,0 +1,202 @@
+# Glossary
+**Updated:** 2025-09-18 19:08
+
+Shared definitions for CI/CD, Git/GitHub, Supabase, and our house style.  
+When in doubt, link terms here from any doc or PR.
+
+---
+
+### ADR (Architecture Decision Record)
+A small, dated note that captures a decision, the options considered, and the reasons. Lives in `docs/adr/`. See also: [Docs Policy & Map](../policy/docs_policy.md).
+
+### Anonymous Key (Supabase)
+Public client key for Supabase that authenticates anonymous usage within Row-Level Security (RLS) constraints. Never grant admin privileges.
+
+### Approval Gate
+A manual control (e.g., “Require review to deploy to production”). In GitHub Actions use **Environments** with required reviewers. See: [CI/CD Constitution](../policy/ci_cd_constitution.md).
+
+### Artifact (Immutable Artifact)
+The build output you deploy (e.g., container image). Built once per commit; the **same** artifact is promoted to staging then production. See: [CI/CD Constitution](../policy/ci_cd_constitution.md).
+
+### Backfill
+A data migration step that populates or transforms existing rows to satisfy a new schema. Part of **Expand → Migrate → Contract**.
+
+### Batch / Umbrella PR
+A top-level PR that coordinates several small, related PRs (the “micro-PRs”). Lets you merge incrementally while keeping the big picture visible. See: [Branching & PR Protocol](../policy/branching_and_prs.md).
+
+### Blue/Green Deployment
+Two production environments (“blue” live, “green” idle). You deploy to green, switch traffic, and keep blue as rollback. We generally prefer **canary** for MVP.
+
+### Build vs CI (Commit Types)
+**build**: build system or packaging changes. **ci**: continuous integration workflows or configuration changes. See: [Commits & Changelog](../policy/commits_and_changelog.md).
+
+### Canary Release
+Gradual exposure of a feature to a small cohort, watching metrics before widening. Often implemented with **feature flags**. See: [Environments & Secrets](../policy/env_and_secrets.md).
+
+### CHANGELOG (Keep a Changelog)
+Human-readable summary of changes per release in `CHANGELOG.md`. Curated from merged PRs and scripts. See: [Commits & Changelog](../policy/commits_and_changelog.md).
+
+### CI (Continuous Integration)
+Automated checks that run on each change: style, tests, thin smoke. Purpose: **fast feedback**. See: [Minimal CI (Week 1)](../policy/ci_minimal.md).
+
+### CD (Continuous Delivery / Deployment)
+Delivery = changes always releasable; Deployment = actually push to users. Our MVP goal: delivery yes, deployment by manual approval.
+
+### Chore (Commit Type)
+Repository housekeeping like dependency bumps or config tweaks. Use `chore(scope): …` when it doesn’t fit `build` or `ci`.
+
+### Cohort
+A subset of tenants or users who receive a feature first. Controlled with **feature flags**.
+
+### Correlation ID
+A UUID carried across services/logs so you can trace one request end-to-end. See: [CI/CD Constitution](../policy/ci_cd_constitution.md).
+
+### Data Dictionary
+A canonical list of entities, columns, and enumerations the app depends on. Lives in `docs/reference/` (to be added).
+
+### DDL / DML
+**DDL** (Data Definition Language): schema changes (CREATE/ALTER). **DML** (Data Manipulation Language): data changes (INSERT/UPDATE/DELETE).
+
+### Decision Tree (Commit Intent)
+Quick classifier for commits (feat, fix, docs, test, build, ci, style, refactor, chore, perf, revert). Canonical version lives in [Docs Policy & Map](../policy/docs_policy.md).
+
+### Deploy Marker
+A visible marker (with version/SHA) on dashboards/logs so deploys correlate with metrics. See: [CI/CD Constitution](../policy/ci_cd_constitution.md).
+
+### Draft PR
+A pull request opened intentionally before it’s ready to merge so scope and acceptance can be reviewed while work is in progress. See: [Branching & PR Protocol](../policy/branching_and_prs.md).
+
+### E2E (End-to-End) Test
+A test that exercises a full user flow. We keep these thin for MVP; most confidence comes from unit + integration + smoke.
+
+### Environment (Local / Staging / Production / Preview)
+**Local** (optional): developer laptop. **Staging**: auto-deploy on merge to main. **Production**: serves users; approval required. **Preview**: ephemeral per-PR environment (v1). See: [Environments & Secrets](../policy/env_and_secrets.md).
+
+### Environment Variable
+A key/value read at runtime to configure the app per environment (12-factor style).
+
+### Expand → Migrate → Contract
+Our safe migration pattern: add columns/tables (expand), backfill/migrate data, then remove obsolete structures (contract). See: Migrations in [CI/CD Constitution](../policy/ci_cd_constitution.md).
+
+### Feature Flag
+A runtime switch to enable/disable code paths per tenant/user. Enables “merge early, release later.” Each flag has owner, default, removal date. See: [Environments & Secrets](../policy/env_and_secrets.md).
+
+### Fix (Commit Type)
+Bug resolved in runtime behavior. Example: `fix(intake): clamp negative quantities`.
+
+### Golden Path
+The simplest, representative user journey that must always work. Our **smoke test** validates this path after every deploy.
+
+### Hotfix
+A small, urgent fix branched from the last production tag, then merged back into main with a new tag.
+
+### Idempotency / Idempotency Key
+Calling the same mutation twice yields the same effect. A client-provided unique key defends against retries/duplicates. See: [CI/CD Constitution](../policy/ci_cd_constitution.md).
+
+### Immutable
+An artifact or identifier that never changes once created (e.g., image digest, tag with SHA). Enables reliable promotion.
+
+### Integration Test
+Validates the contract between modules (e.g., DB layer + service). Sits between unit tests and E2E tests.
+
+### Issue / Project (GitHub)
+**Issues** track work items; **Projects** group and prioritize them. We keep trackers here, not in git history. See: [Docs Policy & Map](../policy/docs_policy.md).
+
+### Keep a Changelog
+Community format for writing CHANGELOG.md so humans can scan what changed. See: [Commits & Changelog](../policy/commits_and_changelog.md).
+
+### Main (Trunk)
+The protected, always-releasable branch. All feature branches merge here via PR. See: [Branching & PR Protocol](../policy/branching_and_prs.md).
+
+### Micro-PR
+A very small pull request focused on one logical change. Easier to review, safer to merge.
+
+### Migration (Database)
+A repeatable script that changes schema or data. Must be forward-only and safe to rerun. See: [CI/CD Constitution](../policy/ci_cd_constitution.md).
+
+### Observability
+Making behavior visible via logs, metrics, and (later) traces. Includes **deploy markers** and standard IDs. See: [CI/CD Constitution](../policy/ci_cd_constitution.md).
+
+### Perf (Commit Type)
+Performance-only improvement (no behavior change).
+
+### Pipeline / Workflow / Job / Step (GitHub Actions)
+A **workflow** is a YAML file of **jobs**; each job has **steps**. Pipelines run on triggers (PRs, merges, or manual). See: [Minimal CI (Week 1)](../policy/ci_minimal.md).
+
+### PR (Pull Request)
+A proposal to merge changes. For us, PRs start as Draft, declare intent, and include acceptance bullets. See: [Branching & PR Protocol](../policy/branching_and_prs.md).
+
+### Preview Environment
+An ephemeral, per-PR deployment to click around safely. Useful in v1; out-of-scope for MVP.
+
+### Production
+The live environment for users. Access is least privilege; deploys require approval.
+
+### Refactor (Commit Type)
+Internal change that doesn’t alter behavior (e.g., extracting functions).
+
+### Release (Tag)
+A semantic, immutable label (e.g., `mvp-0.6.0`) applied to `main` to mark a version.
+
+### Release Notes
+Human-readable summary of what’s in a release (also published as GitHub Release). See: [Release Playbook](../runbooks/release_playbook.md).
+
+### RLS (Row-Level Security)
+Postgres policy system (used by Supabase) that filters rows per user/tenant. Ensures tenants can only see their own data.
+
+### Rollback
+Returning the system to a previous healthy artifact or turning a flag off. Prefer rollback over hot-fixing in production.
+
+### Scope (Commit Scope)
+A short identifier in parentheses that narrows the commit (e.g., `feat(intake): …`). Helps generate focused release notes. See: [Commits & Changelog](../policy/commits_and_changelog.md).
+
+### Secret
+Sensitive value (keys, tokens). In GitHub, store in **Environments**; locally use `.env` templates (never commit real secrets). See: [Environments & Secrets](../policy/env_and_secrets.md).
+
+### SemVer (Semantic Versioning)
+Major.Minor.Patch. Pre-1.0 we bump **Minor** for features and **Patch** for fixes. See: [Commits & Changelog](../policy/commits_and_changelog.md).
+
+### Service Role (Supabase)
+Admin-level key used for server-side operations. Treat as highly sensitive; never ship to clients.
+
+### SLA / SLO / SLI
+**SLA**: external promise. **SLO**: internal target (e.g., 99.9% success). **SLI**: measured indicator (e.g., success rate). We start with light SLOs in v1.
+
+### Smoke Test
+A small, brutal test verifying the Golden Path right after a deploy. Failure blocks or rolls back. See: [Minimal CI (Week 1)](../policy/ci_minimal.md) and [Release Playbook](../runbooks/release_playbook.md).
+
+### Squash Merge
+Merging a PR as a single commit to keep history clean. See: [Branching & PR Protocol](../policy/branching_and_prs.md).
+
+### Staging
+Pre-production environment that mirrors prod closely. Auto-deploy on merge to main for rehearsal.
+
+### Tag (Git)
+A named pointer to a commit, often used for releases. Immutable by convention.
+
+### Tenant
+An isolated customer/account space. All data and actions are scoped by `tenant_id` and RLS.
+
+### Test Pyramid
+Emphasis on many fast unit tests, fewer integration tests, and very few E2E tests.
+
+### Trunk-Based Development
+Working on short-lived branches that frequently merge into `main` (the trunk). See: [Branching & PR Protocol](../policy/branching_and_prs.md).
+
+### UAT (User Acceptance Testing)
+Human verification that behavior meets expectations. For MVP we do this in **staging** or behind flags in **production**.
+
+### Umbrella PR
+See **Batch / Umbrella PR**.
+
+### Unit Test
+Small, fast test for a single function or module.
+
+### VERSION (File)
+The single source of truth for the app’s version, displayed in-app and used for tagging.
+
+### Version Pinning
+Locking a dependency to a specific version to avoid surprise changes.
+
+### Zero-Downtime Migration
+Schema/data evolution done without taking the app offline, usually via **Expand → Migrate → Contract**.

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -1,5 +1,5 @@
 # Glossary
-**Updated:** 2025-09-18 19:08
+**Updated:** 2025-09-18 20:03
 
 Shared definitions for CI/CD, Git/GitHub, Supabase, and our house style.  
 When in doubt, link terms here from any doc or PR.
@@ -18,8 +18,14 @@ A manual control (e.g., “Require review to deploy to production”). In GitHub
 ### Artifact (Immutable Artifact)
 The build output you deploy (e.g., container image). Built once per commit; the **same** artifact is promoted to staging then production. See: [CI/CD Constitution](../policy/ci_cd_constitution.md).
 
+### Artifact Registry
+A repository that stores built artifacts (e.g., container registry). Critical for “build once, promote many.”
+
 ### Backfill
 A data migration step that populates or transforms existing rows to satisfy a new schema. Part of **Expand → Migrate → Contract**.
+
+### Back-merge
+Merging a change from a release or hotfix branch back into `main` so histories remain consistent.
 
 ### Batch / Umbrella PR
 A top-level PR that coordinates several small, related PRs (the “micro-PRs”). Lets you merge incrementally while keeping the big picture visible. See: [Branching & PR Protocol](../policy/branching_and_prs.md).
@@ -29,6 +35,13 @@ Two production environments (“blue” live, “green” idle). You deploy to g
 
 ### Build vs CI (Commit Types)
 **build**: build system or packaging changes. **ci**: continuous integration workflows or configuration changes. See: [Commits & Changelog](../policy/commits_and_changelog.md).
+
+### Breaking Change
+A change that requires users or other systems to adapt immediately (API contract change, destructive schema change without compatibility, removed behavior).  
+How to mark it:
+- Conventional Commits: `feat!:` or `fix!:` **and** add a `BREAKING CHANGE:` footer describing impact and required actions.  
+- Versioning pre-1.0: bump **Minor** (Y).  
+- Process: include migration steps in the PR, add a clear **Changed** note in the [CHANGELOG](../../CHANGELOG.md), and ensure flags/rollback are ready.
 
 ### Canary Release
 Gradual exposure of a feature to a small cohort, watching metrics before widening. Often implemented with **feature flags**. See: [Environments & Secrets](../policy/env_and_secrets.md).
@@ -58,7 +71,7 @@ A canonical list of entities, columns, and enumerations the app depends on. Live
 **DDL** (Data Definition Language): schema changes (CREATE/ALTER). **DML** (Data Manipulation Language): data changes (INSERT/UPDATE/DELETE).
 
 ### Decision Tree (Commit Intent)
-Quick classifier for commits (feat, fix, docs, test, build, ci, style, refactor, chore, perf, revert). Canonical version lives in [Docs Policy & Map](../policy/docs_policy.md).
+Quick classifier for commits (feat, fix, docs, test, build, ci, style, refactor, chore, perf, revert). Canonical version lives in [Conventional Commits & Changelog](../policy/commits_and_changelog.md).
 
 ### Deploy Marker
 A visible marker (with version/SHA) on dashboards/logs so deploys correlate with metrics. See: [CI/CD Constitution](../policy/ci_cd_constitution.md).
@@ -87,8 +100,11 @@ Bug resolved in runtime behavior. Example: `fix(intake): clamp negative quantiti
 ### Golden Path
 The simplest, representative user journey that must always work. Our **smoke test** validates this path after every deploy.
 
+### GitHub Environment
+A named environment in GitHub with scoped secrets and protection rules (e.g., require reviewers to deploy to production).
+
 ### Hotfix
-A small, urgent fix branched from the last production tag, then merged back into main with a new tag.
+A small, urgent fix branched from the last production tag, then merged back into `main` with a new tag.
 
 ### Idempotency / Idempotency Key
 Calling the same mutation twice yields the same effect. A client-provided unique key defends against retries/duplicates. See: [CI/CD Constitution](../policy/ci_cd_constitution.md).
@@ -104,6 +120,9 @@ Validates the contract between modules (e.g., DB layer + service). Sits between 
 
 ### Keep a Changelog
 Community format for writing CHANGELOG.md so humans can scan what changed. See: [Commits & Changelog](../policy/commits_and_changelog.md).
+
+### Linear History
+A repository setting that enforces merges as single commits (squash) to avoid complex graph histories.
 
 ### Main (Trunk)
 The protected, always-releasable branch. All feature branches merge here via PR. See: [Branching & PR Protocol](../policy/branching_and_prs.md).
@@ -132,6 +151,9 @@ An ephemeral, per-PR deployment to click around safely. Useful in v1; out-of-sco
 ### Production
 The live environment for users. Access is least privilege; deploys require approval.
 
+### Protected Branch / Branch Protection
+Rules that guard `main` (require status checks, linear history, PRs before merge).
+
 ### Refactor (Commit Type)
 Internal change that doesn’t alter behavior (e.g., extracting functions).
 
@@ -144,8 +166,14 @@ Human-readable summary of what’s in a release (also published as GitHub Releas
 ### RLS (Row-Level Security)
 Postgres policy system (used by Supabase) that filters rows per user/tenant. Ensures tenants can only see their own data.
 
+### Roll-forward
+Fix forward with a new commit and redeploy, instead of rolling back.
+
 ### Rollback
 Returning the system to a previous healthy artifact or turning a flag off. Prefer rollback over hot-fixing in production.
+
+### SBOM (Software Bill of Materials)
+A manifest of components and versions in your artifact. Useful for security and compliance; v1 item.
 
 ### Scope (Commit Scope)
 A short identifier in parentheses that narrows the commit (e.g., `feat(intake): …`). Helps generate focused release notes. See: [Commits & Changelog](../policy/commits_and_changelog.md).

--- a/docs/runbooks/github_projects_setup.md
+++ b/docs/runbooks/github_projects_setup.md
@@ -1,0 +1,133 @@
+# GitHub Projects — Field Schema, Colors & Saved Views (Paste-and-do)
+Updated: 2025-09-19 16:18
+
+Goal: stand up a single Project that tracks **Specs, Policies, Runbooks, and Delivery** — using one set of fields, consistent **colors**, clear **descriptions**, and a few saved views. No external tools required.
+
+---
+
+## 0) Create the Project
+- Scope: Repository Project (good enough for solo) or Organization Project if you want cross-repo later.
+- Name: “Menu Optimizer — Product & CI/CD”
+
+---
+
+## 1) Add custom fields (names, types, colors, descriptions)
+Add each via “+ Add field”. Colors reference the standard GitHub palette (pick the closest if exact name differs). Keep names short to reduce friction.
+
+### Field: Status — *Single select*
+**Purpose:** lifecycle across both product and process items.  
+**Color-by recommendation for Boards:** *Color by Status* for instant scan value.
+
+Options (name — color — description):
+- **Draft** — Gray — Idea captured; not ready for review. Needs acceptance bullets or problem statement.  
+- **In review** — Blue — Under active review (e.g., spec PR open). Expect comments/edits.  
+- **Accepted** — Purple — Agreed scope/policy. Ready to plan or implement.  
+- **Parked** — Purple — Intentionally paused; add a short “revisit by” note.  
+- **Todo** — Yellow — Ready to start; acceptance clear; no blockers.  
+- **Doing** — Orange — In progress.  
+- **Done** — Green — Complete. For code: merged + deployed/flag ON. For docs: merged + linked in Bible.
+
+*(Optional later: **Blocked** — Red — Can’t progress; add “blocked by” in the item body.)*
+
+### Field: Type — *Single select*
+**Purpose:** what kind of work this is.  
+**Recommendation:** Use these colors consistently across repos.
+
+Options (name — color — description):
+- **Spec** — Purple — Product spec under review/acceptance.  
+- **Policy** — Orange — Governance/process docs (e.g., branching, CI).  
+- **Runbook** — Pink — Operational how-tos (e.g., release playbook).  
+- **Feature** — Blue — User-visible behavior change.  
+- **Bug** — Red — Regression or incorrect behavior.  
+- **Chore** — Gray — Repo/infra housekeeping; low user impact.
+
+### Field: Priority — *Single select*
+**Purpose:** triage and sequencing.  
+**Options:**
+- **P0** — Red — Now; breaks commitments or critical path.  
+- **P1** — Orange — Next up; important for MVP scope.  
+- **P2** — Yellow — Nice to have for MVP; otherwise v1.  
+- **P3** — Gray — Low priority; backlog parking.
+
+### Field: Target Release — *Text* (or **Iteration** later)
+**Purpose:** human milestone (e.g., `mvp-0.7.0`). If you care about dates, switch to **Iteration**.
+
+### Field: Area — *Single select*
+**Purpose:** where it belongs in product/platform.  
+**Options (suggested colors):**
+- **intake** — Teal — Menu intake & editor flows.  
+- **identity** — Blue — Auth & tenant membership.  
+- **measure** — Yellow — Metrics & analytics.  
+- **chronicle** — Purple — Audit/history/chronicles.  
+- **lexicon** — Pink — Shared vocab, dictionaries.  
+- **ui** — Cyan — UI components/layout.  
+- **db** — Indigo — Schema/migrations/data.  
+- **ci** — Orange — CI/CD pipelines & envs.  
+- **policy** — Gray — Governance docs.  
+- **runbooks** — Green — Operational guides.
+
+### Field: Doc Link — *Text*
+**Purpose:** authoritative in-repo path (e.g., `docs/specs/04_Intake_MVP_Specs.md`).
+
+### Field: PR Link — *Text*
+**Purpose:** review artifact tying discussion to change (paste the PR URL).
+
+---
+
+## 2) Saved views (create these)
+Create each “New view” and set filters/group/sort as described. Rename the view with the title below.
+
+### A) Specs Review (Table)
+- Filter: **Type** is “Spec”  
+- Group by: **Status**  
+- Sort by: **Priority** (ascending), then **Title**  
+- Show fields: Status · Type · Priority · Target Release · Doc Link · PR Link · Area
+
+### B) Delivery Board (Board)
+- Filter: **Type** is not “Spec”  
+- Columns: **Status** (Draft, In review, Accepted, Parked, Todo, Doing, Done)  
+- **Card color:** *Status*  
+- Card layout: Title · Type · Priority · Target Release · Area
+
+### C) Policy & Runbooks (Table)
+- Filter: **Type** is any of “Policy”, “Runbook”  
+- Group by: **Type**  
+- Sort by: **Title**  
+- Show fields: Status · Priority · Doc Link · PR Link
+
+### D) Roadmap (optional)
+- Layout: **Roadmap**  
+- Time source: **Target Release** (text milestones) — or add an **Iteration** field to timebox  
+- Group by: **Type**  
+- Filter: exclude “Chore”
+
+---
+
+## 3) Lightweight automation (manual-first, optional later)
+MVP: update **Status** manually during review; fill **Doc/PR Links**.  
+v1: add workflows to auto-add issues/PRs to the Project and nudge Status on PR open/close.
+
+---
+
+## 4) Labels to help triage (optional)
+Create repo labels that mirror **Type** (spec, policy, runbook, feature, bug, chore) and **Area** (intake, identity, …). Nice for quick filters even outside the Project.
+
+---
+
+## 5) Workflow handshake (specs)
+Use the “Spec Review” Issue template at `.github/ISSUE_TEMPLATE/spec_review.md`. When you open a spec Issue:
+- Add it to **Specs Review**.  
+- Set **Type = Spec**, **Status = Draft**, **Doc Link = path to spec**.  
+- Open a Draft PR to propose acceptance → **Status = In review**; fill **PR Link**.  
+- After approval → **Status = Accepted** and link the merged PR.
+
+---
+
+## 6) Field glossary (quick)
+- **Status**: lifecycle across product and process items (color by this on Boards).  
+- **Type**: kind of work; colors are consistent across repos.  
+- **Area**: product/platform neighborhood.  
+- **Target Release**: your version milestone; optionally an Iteration.  
+- **Doc/PR Links**: create a tight handshake between docs, PRs, and the Project.
+
+That’s it. This one Project becomes your **Town Square** you can slice by Status, Type, Area, or Release—without leaving GitHub.

--- a/docs/runbooks/release_playbook.md
+++ b/docs/runbooks/release_playbook.md
@@ -1,0 +1,143 @@
+# Release Playbook — MVP
+**Updated:** 2025-09-19 13:17
+
+Applies to: Streamlit app + Supabase Postgres (multi-tenant)  
+Related: [CI/CD Constitution](../policy/ci_cd_constitution.md), [Minimal CI](../policy/ci_minimal.md), [Commits & Changelog](../policy/commits_and_changelog.md), [Environments & Secrets](../policy/env_and_secrets.md), [Branching & PR Protocol](../policy/branching_and_prs.md).
+
+Purpose: a repeatable, low‑risk path from `main` to staging and production with clear checkpoints, rollback, and documentation.
+
+---
+
+## 0) Preconditions
+- `main` is green (all required checks passing).  
+- No open critical Issues linked to the milestone.  
+- Database migrations follow **Expand → Migrate → Contract** and are idempotent.  
+- Feature flags for this release are documented in the PR(s).
+
+---
+
+## 1) Version bump
+- Update `VERSION` with `mvp-X.Y.Z` scheme. Pre‑1.0: bump **Y** for features/breaking changes, **Z** for fixes.  
+- Commit with: `chore(release): bump version to mvp-X.Y.Z`.
+
+Optional helper scripts (if present):
+- `verify_release.sh` — sanity checks (`VERSION` matches, clean tree, on `main`).  
+- `gen_changelog.py` — update `CHANGELOG.md` from merged PRs (edit as needed).  
+- `release_notes.sh` — draft GitHub Release notes from the changelog.
+
+---
+
+## 2) Tag
+- Create an annotated tag on `main`: `mvp-X.Y.Z`.  
+- Push the tag. This should trigger the **build-and-stage** workflow (see [Minimal CI](../policy/ci_minimal.md)).
+
+Tag message template:
+- Title: `mvp-X.Y.Z`  
+- Body: paste curated sections from `CHANGELOG.md` (Added / Changed / Fixed / Removed / Security).
+
+---
+
+## 3) Staging deploy
+Triggered automatically from tag push (or merge to `main`, depending on workflow):
+
+- Build **immutable artifact** for the tag; label with version + SHA.  
+- Deploy to **staging** using environment‑scoped secrets.  
+- Add a **deploy marker** with version + SHA.  
+- Run post‑deploy **smoke** (Golden Path) in staging.
+
+Gate to proceed:
+- Smoke green.  
+- No new errors or regressions in metrics/logs for an agreed soak window (e.g., 10–30 minutes).
+
+If staging fails:
+- **Rollback** to last green artifact or fix forward and redeploy.  
+- Update the release PR or notes with the decision and outcome.
+
+---
+
+## 4) Production promotion
+Manual approval via GitHub **production** environment.
+
+- Deploy the **same artifact** used in staging.  
+- Add **deploy marker**.  
+- Run **smoke** again.  
+- Watch key metrics (error rate, success rate, latency) for the soak window.
+
+If production smoke fails or SLOs degrade:
+- **Rollback** immediately to previous tag.  
+- If the fix is trivial and safer than rollback, **roll forward** with a `hotfix/…` from the latest tag; tag `mvp-X.Y.(Z+1)`.
+
+Document the incident briefly in the release notes.
+
+---
+
+## 5) Post‑release tasks
+- **Close milestone** and related Issues.  
+- Ensure `CHANGELOG.md` and GitHub Release page match.  
+- Confirm flags’ intended **defaults** in production.  
+- Capture any follow‑ups as Issues (e.g., remove temporary code; schedule **Contract** phase of migrations).  
+- Record a short summary in the project log (one paragraph).
+
+---
+
+## 6) Rollback playbook
+Use when production smoke fails or a severe regression appears.
+
+1. Identify last good tag (e.g., `mvp-X.Y.(Z-1)`).  
+2. Promote its artifact to production (no rebuild).  
+3. Post a deploy marker `ROLLBACK mvp-X.Y.Z → mvp-X.Y.(Z-1)`.  
+4. Disable related feature flags.  
+5. Open an Incident Issue with: **Impact, Timeline, Suspected Cause, Fix plan**.  
+6. Decide **fix forward** vs **hold**. If fix forward:
+   - Branch `hotfix/short-slug` from last good tag.  
+   - Make minimal change; PR → squash → tag `mvp-X.Y.(Z+1)` → stage → prod.  
+7. Update `CHANGELOG.md` and Release notes.
+
+---
+
+## 7) Database migrations (safe path)
+- **Expand**: additive DDL first; keep app reading both shapes.  
+- **Migrate**: backfill using idempotent scripts under `migrations/sql/` (e.g., `V003__add_tenant_id.sql`).  
+- **Contract**: remove old structures only after a full release cycle with telemetry showing safety.
+
+If a migration breaks staging or prod:
+- Revert application behavior flag‑off; **do not** drop columns under pressure.  
+- Create a corrective migration script; run in staging; then redo promotion.
+
+---
+
+## 8) Communications
+- Internal: short note in the PR or project log: version, date/time, highlights, known issues.  
+- External (optional): update customer‑facing channel if relevant (feature flag on, new behavior visible).
+
+---
+
+## 9) Quality gates (summary)
+- PR checks: style, unit, thin smoke → must pass.  
+- Staging gate: post‑deploy smoke + metrics stable.  
+- Production gate: manual approval + smoke + metrics stable.
+
+---
+
+## 10) Checklist (copy into release Issue if you prefer)
+- [ ] `VERSION` updated to `mvp-X.Y.Z`  
+- [ ] `CHANGELOG.md` curated for this version  
+- [ ] Tag `mvp-X.Y.Z` created and pushed  
+- [ ] Staging deployed; smoke passed; metrics stable  
+- [ ] Production approved; same artifact promoted  
+- [ ] Production smoke passed; metrics stable  
+- [ ] Flags set to intended defaults  
+- [ ] Milestone closed; follow‑ups filed  
+- [ ] Release notes published (GitHub Release)
+
+---
+
+## 11) v1 enhancements (parked)
+- Per‑PR preview environments for richer UAT.  
+- Automated dependency audit and security scans.  
+- SBOM and artifact signing.  
+- Canary at infra level and progressive delivery tools.
+
+---
+
+**File conventions used in this doc are wrapped in backticks to avoid accidental links (e.g., `VERSION`, `V003__add_tenant_id.sql`).**

--- a/docs/specs/spec_template.md
+++ b/docs/specs/spec_template.md
@@ -1,0 +1,165 @@
+# &lt;Spec title&gt;
+
+**Status:** Draft • **Created:** 2025-09-19 18:59  
+**Spec ID:** &lt;YYYY-MM-DD-short-slug or NN_Module_MVP_Spec&gt;  
+**Owner:** &lt;name&gt;  
+**Links:** Project item • PR • Discussions
+
+> Tip: Create this file in a branch named `spec/<short-slug>`. Only **Accepted** specs live in `docs/specs/` on `main`. See: [Specs Workflow & Acceptance](../policy/specs_workflow.md).
+
+---
+
+## 1) Executive summary
+
+**Purpose — one paragraph:** What problem are we solving for whom, and why now? Make it human.  
+**Outcome — one sentence:** What must be true when this work is done?
+
+**Meta (edit inline):**
+
+| Field | Value |
+|---|---|
+| Area | &lt;intake • identity • measure • chronicle • lexicon • ui • db • ci • policy • runbooks&gt; |
+| Type | Spec |
+| Priority | &lt;P0 • P1 • P2 • P3&gt; |
+| Target release | `mvp-<X.Y.Z>` |
+| Risk level | &lt;Low • Medium • High&gt; |
+| Rollout strategy | &lt;Flag • Staged • Big-bang&gt; |
+
+---
+
+## 2) Goals and non‑goals
+
+**Goals** (must happen):  
+- [ ] …  
+- [ ] …  
+
+**Non‑goals** (explicitly *not* doing):  
+- …  
+- …  
+
+> Note: Non‑goals are guardrails that keep scope honest.
+
+---
+
+## 3) Users & tenants impacted
+
+Who touches this and how? Any multi‑tenant/RLS considerations, permissions, or abuse cases to foresee.
+
+---
+
+## 4) Happy‑path scenarios
+
+Describe the shortest successful journeys. Two or three is plenty.
+
+1. As a &lt;user/tenant&gt;, I … and see …  
+2. As a &lt;role&gt;, I … and the system …
+
+> Keep these concise; they become your smoke checks later.
+
+---
+
+## 5) Out of scope
+
+Bullet the edges that remain out, to prevent scope creep.
+
+- …  
+- …
+
+---
+
+## 6) Risks & assumptions
+
+- **Risks:** &lt;what could bite us&gt;  
+- **Assumptions:** &lt;what we’re betting on&gt;  
+- **Open questions:** &lt;known unknowns&gt;
+
+> If risk is High, consider a feature flag and a rollback plan.
+
+---
+
+## 7) Data & migrations (if any)
+
+- Schema deltas (DDL): describe the **Expand → Migrate → Contract** plan.  
+- Backfills (DML): outline idempotent jobs and timing.  
+- Snapshots/rollbacks: how to revert safely if needed.
+
+Reference planned scripts under `migrations/sql/` (e.g., `V003__add_tenant_id.sql`). See: [CI/CD Constitution](../policy/ci_cd_constitution.md).
+
+---
+
+## 8) Feature flags (if any)
+
+- **Flag name:** …  
+- **Owner:** …  
+- **Default:** OFF / ON  
+- **Kill switch behavior:** …  
+- **Removal date:** …  
+- **Cohort rollout:** &lt;tenants • % of traffic&gt;
+
+> Flags let you merge early, release later. Pair with telemetry before widening.
+
+---
+
+## 9) Observability
+
+**Smoke after deploy** (turn into automated checks if possible):  
+- [ ] Golden Path loads &lt;page/flow&gt; without error  
+- [ ] &lt;Key assertion&gt; succeeds
+
+**Events/metrics to watch:**  
+- `event_name` with `tenant_id`, `request_id`, `correlation_id`  
+- Error rate, latency, success % for &lt;endpoint/flow&gt;
+
+**Deploy marker:** `mvp-<X.Y.Z>` with commit SHA.
+
+See: [CI/CD Constitution](../policy/ci_cd_constitution.md).
+
+---
+
+## 10) Acceptance bullets (merge‑ready checklist)
+
+- [ ] Users can … (actionable, testable)  
+- [ ] UI shows … under … conditions  
+- [ ] Flags configured (owner/default/kill switch/removal date)  
+- [ ] Migrations shipped as `migrations/sql/V***__*.sql` and idempotent  
+- [ ] Observability in place (events/metrics + deploy marker)  
+- [ ] Docs updated (README, user docs if relevant)
+
+> Write these like you’ll verify them. Action verbs. No ambiguity.
+
+---
+
+## 11) Rollout plan
+
+**Staging:** deploy on merge to `main`; run smoke; observe for a soak window of &lt;minutes&gt;.  
+**Production:** manual approval via GitHub Environment; small tenant cohort first if flagged.  
+**Rollback:** criteria and steps if smoke or SLOs fail.
+
+See: [Release Playbook](../runbooks/release_playbook.md).
+
+---
+
+## 12) Dependencies
+
+Upstream/downstream systems, libraries, data, or other specs. Include links.
+
+- Depends on: …  
+- Affects: …
+
+---
+
+## 13) Changelog impact
+
+Will this produce user‑visible changes? If yes, the implementing PRs should add entries to `CHANGELOG.md` under **Added/Changed/Fixed** following [Conventional Commits & Changelog](../policy/commits_and_changelog.md).
+
+---
+
+## 14) Version history
+
+- 2025-09-19 18:59: Draft created  
+- &lt;YYYY‑MM‑DD&gt;: Accepted (MVP)
+
+---
+
+> Example filenames are wrapped in backticks to avoid accidental links (e.g., `docs/specs/04_Intake_MVP_Specs.md`, `V003__add_tenant_id.sql`).  
+> Terms are defined in the [Glossary](../reference/glossary.md).


### PR DESCRIPTION
# Because
Development is slowed down by lack of structure and best practices

# Changed
We are implementing a CI/CD framework supported by exhaustive documentation.

# Result
Everyone will know where files go, what process to follow, have a common understanding of definitions.

# Done when the following files are created:
- [x] Project Bible (docs/README.md)
- [x] Docs Policy & Map (docs/policy/docs_policy.md)
- [x] PR Template (.github/pull_request_template.md)
- [x] Branching & PR Protocol (docs/policy/branching_and_prs.md)
- [x] Conventional Commits & Changelog Rules (docs/policy/commits_and_changelog.md)
- [x] CI/CD Constitution (docs/policy/ci_cd_constitution)
- [x] Minimal CI (Week 1) (docs/policy/ci_minimal.md)
- [x] Environments & Secrets (SimplerTree)  (docs/policy/env_and_secrets.md)
- [x] Release Playbook (docs/runbooks/release_playbook.md)
- [x] CONTRIBUTING (mini) (/CONTRIBUTING.md)
- [x] Glossary (docs/reference/glossary.md)

# Out of scope
- MVP Operational Docs
- Collaboration & Scale-Ready docs
- v1 Platform Docs

# Risks / Rollback
No risks

# Changelog
Added — Phase 0 Documentation as foundation of our CI/CD framework

---

## Meta

- Branch: `Docs/phase0`