### PR TITLE
chore(automation): seed Issues/Epics from Markdown (#22)

### DIFF
--- a/.github/project-seeds/pending/phase1a-epic.md
+++ b/.github/project-seeds/pending/phase1a-epic.md
@@ -8,6 +8,7 @@ children_uids: ["ci-cd-phase1a-workflow","ci-cd-phase1a-schema","ci-cd-phase1a-f
 mode: create_only
 frozen: true
 lifecycle: seed_only
+
 -->
 
 # Epic: CI/CD Phase 1A — Project Exporter

--- a/.github/project-seeds/pending/phase1a-epic.md
+++ b/.github/project-seeds/pending/phase1a-epic.md
@@ -8,7 +8,6 @@ children_uids: ["ci-cd-phase1a-workflow","ci-cd-phase1a-schema","ci-cd-phase1a-f
 mode: create_only
 frozen: true
 lifecycle: seed_only
-
 -->
 
 # Epic: CI/CD Phase 1A — Project Exporter

--- a/.github/project-seeds/pending/phase1a-epic.md
+++ b/.github/project-seeds/pending/phase1a-epic.md
@@ -1,0 +1,21 @@
+<!--
+title: Epic: CI/CD Phase 1A — Project Exporter
+labels: ["epic","CI/CD-phase:phase-1a"]
+uid: ci-cd-phase1a-epic
+children_uids: ["ci-cd-phase1a-workflow","ci-cd-phase1a-schema","ci-cd-phase1a-first-export"]
+
+# snapshot semantics (create-only)
+mode: create_only
+frozen: true
+lifecycle: seed_only
+-->
+
+# Epic: CI/CD Phase 1A — Project Exporter
+
+## Intent
+Produce portable snapshots of the Project for coordination and metrics without touching CI gates.
+
+## Acceptance
+- [ ] Exporter workflow exists and runs on manual trigger (no schedule yet)
+- [ ] Snapshot schema documented (JSON/MD artifacts, fields, enums)
+- [ ] First manual export committed (`project_sync/project_state.json` and `project_status.md`)

--- a/.github/project-seeds/pending/phase1a-first-export.md
+++ b/.github/project-seeds/pending/phase1a-first-export.md
@@ -7,7 +7,6 @@ parent_uid: ci-cd-phase1a-epic
 mode: create_only
 frozen: true
 lifecycle: seed_only
-
 -->
 
 ## Intent

--- a/.github/project-seeds/pending/phase1a-first-export.md
+++ b/.github/project-seeds/pending/phase1a-first-export.md
@@ -1,0 +1,18 @@
+<!--
+title: chore: Phase 1A — perform first manual export
+labels: ["chore","CI/CD-phase:phase-1a"]
+uid: ci-cd-phase1a-first-export
+parent_uid: ci-cd-phase1a-epic
+
+mode: create_only
+frozen: true
+lifecycle: seed_only
+-->
+
+## Intent
+Run the exporter once, attach artifacts, and verify the snapshot makes sense.
+
+## Acceptance
+- [ ] Export action run link attached.
+- [ ] `project_sync/project_state.json` and `project_status.md` present (or attached).
+- [ ] Quick note on any field mismatches to fix in the next iteration.

--- a/.github/project-seeds/pending/phase1a-first-export.md
+++ b/.github/project-seeds/pending/phase1a-first-export.md
@@ -7,6 +7,7 @@ parent_uid: ci-cd-phase1a-epic
 mode: create_only
 frozen: true
 lifecycle: seed_only
+
 -->
 
 ## Intent

--- a/.github/project-seeds/pending/phase1a-schema.md
+++ b/.github/project-seeds/pending/phase1a-schema.md
@@ -7,7 +7,6 @@ parent_uid: ci-cd-phase1a-epic
 mode: create_only
 frozen: true
 lifecycle: seed_only
-
 -->
 
 ## Intent

--- a/.github/project-seeds/pending/phase1a-schema.md
+++ b/.github/project-seeds/pending/phase1a-schema.md
@@ -7,6 +7,7 @@ parent_uid: ci-cd-phase1a-epic
 mode: create_only
 frozen: true
 lifecycle: seed_only
+
 -->
 
 ## Intent

--- a/.github/project-seeds/pending/phase1a-schema.md
+++ b/.github/project-seeds/pending/phase1a-schema.md
@@ -1,0 +1,19 @@
+<!--
+title: docs: Phase 1A — exporter snapshot schema
+labels: ["docs","CI/CD-phase:phase-1a"]
+uid: ci-cd-phase1a-schema
+parent_uid: ci-cd-phase1a-epic
+
+mode: create_only
+frozen: true
+lifecycle: seed_only
+-->
+
+## Intent
+Document the schema for `project_state.json` and `project_status.md`:
+- [ ] stable field names (Status, Track, Phase, Priority)
+- [ ] allowed values and mapping rules
+- [ ] how parent/child links are represented
+
+## Acceptance
+- [ ] `docs/policy/project_export_schema.md` merged and linked from `docs/README.md`.

--- a/.github/project-seeds/pending/phase1a-workflow.md
+++ b/.github/project-seeds/pending/phase1a-workflow.md
@@ -7,7 +7,6 @@ parent_uid: ci-cd-phase1a-epic
 mode: create_only
 frozen: true
 lifecycle: seed_only
-
 -->
 
 ## Intent

--- a/.github/project-seeds/pending/phase1a-workflow.md
+++ b/.github/project-seeds/pending/phase1a-workflow.md
@@ -1,0 +1,19 @@
+<!--
+title: ci: Phase 1A — add Project Exporter workflow (manual trigger)
+labels: ["ci","CI/CD-phase:phase-1a"]
+uid: ci-cd-phase1a-workflow
+parent_uid: ci-cd-phase1a-epic
+
+mode: create_only
+frozen: true
+lifecycle: seed_only
+-->
+
+## Intent
+Add `.github/workflows/project_export.yml` that, on `workflow_dispatch`, writes:
+- [ ] `project_sync/project_state.json` (items, fields, parent/child)
+- [ ] `project_sync/project_status.md` (counts, per-epic progress)
+
+## Acceptance
+- [ ] Run completes and commits artifacts on a branch or as workflow artifacts.
+- [ ] Does NOT run on a schedule in Phase 1A.

--- a/.github/project-seeds/pending/phase1a-workflow.md
+++ b/.github/project-seeds/pending/phase1a-workflow.md
@@ -7,6 +7,7 @@ parent_uid: ci-cd-phase1a-epic
 mode: create_only
 frozen: true
 lifecycle: seed_only
+
 -->
 
 ## Intent

--- a/.github/workflows/seed-project-items.yml
+++ b/.github/workflows/seed-project-items.yml
@@ -6,7 +6,6 @@ on:
       - ".github/project-seeds/pending/**.md"
   workflow_dispatch:
 
-# GITHUB_TOKEN perms needed for issues, PR, and repo-projects (Project v2 via GraphQL)
 permissions:
   contents: write
   issues: write
@@ -26,7 +25,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: List pending seed files (robust on first push & shallow diffs)
+      - name: List pending seed files
         id: list
         shell: bash
         run: |
@@ -36,51 +35,46 @@ jobs:
           SEED_GLOB=".github/project-seeds/pending/**.md"
 
           if [ -z "${BEFORE}" ] || [ "${BEFORE}" = "0000000000000000000000000000000000000000" ]; then
-            # First push to branch (no parent) → list all tracked seeds
             git ls-files "${SEED_GLOB}" > seeds.txt || true
           else
-            # Only files touched in this push → group pipeline, redirect once
             ( git diff --name-only "${BEFORE}" "${AFTER}" \
               | grep -E "^\.github/project-seeds/pending/.*\.md$" || true ) > seeds.txt
           fi
 
-          echo "files=$(paste -sd, seeds.txt)" >> "$GITHUB_OUTPUT"
+          FILES="$(paste -sd, seeds.txt || true)"
+          echo "files=${FILES}" >> "$GITHUB_OUTPUT"
           echo "Seeds to process:"
           cat seeds.txt || true
 
       - name: Create issues (create-only) and add to Project
-        if: steps.list.outputs.files != ''
         id: create
+        if: steps.list.outputs.files != ''
         uses: actions/github-script@v7
         env:
-          # Prefer repo-level variables over hard-coding
-          DEFAULT_PROJECT_URL: ${{ vars.PROJECT_URL }}
+          FILES:                ${{ steps.list.outputs.files }}
+          DEFAULT_PROJECT_URL:  ${{ vars.PROJECT_URL }}
           DEFAULT_ASSIGNEE:     ${{ vars.DEFAULT_ASSIGNEE }}
           FALLBACK_ASSIGNEE:    ${{ github.actor }}
         with:
           script: |
-            // actions/github-script provides 'core', 'github', and 'context' globals.
+            // 'core', 'github', 'context' are provided
             const fs = require('fs');
             const path = require('path');
 
-            const files = core.getInput('files').split(',').filter(Boolean);
+            const files = (process.env.FILES || '').split(',').filter(Boolean);
             if (!files.length) { core.setOutput('created','[]'); return; }
 
-            // --- helpers -----------------------------------------------------
             function parseHeader(body) {
-              // Header block is an HTML comment at the top of the seed file.
               const m = body.match(/<!--([\s\S]*?)-->/);
               if (!m) return { meta:{}, rest: body.trim() };
               const hdr = m[1];
               const meta = {};
               hdr.split('\n').forEach(line => {
                 const L = line.trim();
-                if (!L || L.startsWith('#')) return;          // ignore yaml-style notes in header
-                const idx = L.indexOf(':');
-                if (idx < 0) return;
+                if (!L || L.startsWith('#')) return;
+                const idx = L.indexOf(':'); if (idx < 0) return;
                 const k = L.slice(0, idx).trim();
                 let v = L.slice(idx+1).trim();
-                // allow JSON or plain strings
                 try { meta[k] = JSON.parse(v); }
                 catch { meta[k] = v.replace(/^"+|"+$/g,''); }
               });
@@ -91,36 +85,28 @@ jobs:
             async function findIssueByUid(uid) {
               const q = `repo:${context.repo.owner}/${context.repo.repo} in:body "seed-uid:${uid}" type:issue`;
               const res = await github.rest.search.issuesAndPullRequests({ q });
-              // Only issues, not PRs
               return res.data.items.find(i => !i.pull_request) || null;
             }
 
             async function getProjectInfo(projectUrl) {
-              // Accept both org and user Projects v2:
-              // - https://github.com/orgs/ORG/projects/123
-              // - https://github.com/users/USER/projects/1
               const orgMatch  = projectUrl?.match(/orgs\/([^/]+)\/projects\/(\d+)/);
               const userMatch = projectUrl?.match(/users\/([^/]+)\/projects\/(\d+)/);
               if (!orgMatch && !userMatch) return null;
 
               if (orgMatch) {
-                const [_, org, n] = orgMatch;
-                const number = parseInt(n, 10);
+                const [_, org, n] = orgMatch; const num = parseInt(n,10);
                 const data = await github.graphql(
                   `query($org:String!, $num:Int!){
                     organization(login:$org){ projectV2(number:$num){ id } }
-                  }`,
-                  { org, num: number }
+                  }`, { org, num }
                 );
                 return { projectId: data.organization.projectV2.id };
               } else {
-                const [_, user, n] = userMatch;
-                const number = parseInt(n, 10);
+                const [_, user, n] = userMatch; const num = parseInt(n,10);
                 const data = await github.graphql(
                   `query($user:String!, $num:Int!){
                     user(login:$user){ projectV2(number:$num){ id } }
-                  }`,
-                  { user, num: number }
+                  }`, { user, num }
                 );
                 return { projectId: data.user.projectV2.id };
               }
@@ -130,24 +116,21 @@ jobs:
               const node = await github.graphql(
                 `query($o:String!, $r:String!, $n:Int!){
                   repository(owner:$o, name:$r){ issue(number:$n){ id } }
-                }`,
-                { o: context.repo.owner, r: context.repo.repo, n: issueNumber }
+                }`, { o: context.repo.owner, r: context.repo.repo, n: issueNumber }
               );
               await github.graphql(
                 `mutation($projectId:ID!, $contentId:ID!){
                   addProjectV2ItemById(input:{projectId:$projectId, contentId:$contentId}){ item { id } }
-                }`,
-                { projectId, contentId: node.repository.issue.id }
+                }`, { projectId, contentId: node.repository.issue.id }
               );
             }
-            // -----------------------------------------------------------------
 
             const DEFAULT_PROJECT_URL = process.env.DEFAULT_PROJECT_URL || null;
             const DEFAULT_ASSIGNEE    = process.env.DEFAULT_ASSIGNEE || '';
             const FALLBACK_ASSIGNEE   = process.env.FALLBACK_ASSIGNEE || '';
 
-            let projectInfo = null; // one project for all seeds by design
-            const created = [];      // [{ number, uid, meta, createdNew: true }]
+            let projectInfo = null;
+            const created = [];
 
             for (const f of files) {
               const raw = fs.readFileSync(f, 'utf8');
@@ -157,16 +140,12 @@ jobs:
               const labels = Array.isArray(meta.labels) ? meta.labels : (meta.labels ? [meta.labels] : []);
               const uid    = meta.uid || null;
 
-              // Hard "create-only" semantics unless seed says otherwise
               const mode      = String(meta.mode ?? 'create_only');
               const frozen    = String(meta.frozen ?? 'true') === 'true';
               const lifecycle = String(meta.lifecycle ?? 'seed_only');
               const createOnly = (mode === 'create_only') || frozen || (lifecycle === 'seed_only');
 
-              if (!uid) {
-                core.warning(`Seed ${f} missing 'uid'; skipping.`);
-                continue;
-              }
+              if (!uid) { core.warning(`Seed ${f} missing 'uid'; skipping.`); continue; }
 
               const existing = await findIssueByUid(uid);
               if (existing && createOnly) {
@@ -174,7 +153,6 @@ jobs:
                 continue;
               }
 
-              // Assignees: seed > default var > actor > none
               let assignees = [];
               if (Array.isArray(meta.assignees)) assignees = meta.assignees;
               else if (meta.assignees)           assignees = [meta.assignees];
@@ -184,14 +162,12 @@ jobs:
               const projectUrl = meta.project_url || DEFAULT_PROJECT_URL || null;
               const body = `${rest}\n\n<!-- seed-uid:${uid} -->`.trim();
 
-              // CREATE
               const issue = (await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo:  context.repo.repo,
                 title, body, labels, assignees
               })).data;
 
-              // Add to Project (optional)
               if (projectUrl) {
                 if (!projectInfo) projectInfo = await getProjectInfo(projectUrl);
                 if (projectInfo?.projectId) {
@@ -206,22 +182,24 @@ jobs:
 
             core.setOutput('created', JSON.stringify(created));
 
-      - name: Wire hierarchy (epic checklists and late child → existing epic)
+      - name: Wire hierarchy (epic checklists + late child linking)
         if: steps.create.outputs.created != ''
         uses: actions/github-script@v7
+        env:
+          CREATED: ${{ steps.create.outputs.created }}
         with:
           script: |
-            // 'core', 'github', 'context' provided by actions/github-script
+            // 'core', 'github', 'context' provided
             async function findIssueByUid(uid) {
               const q = `repo:${context.repo.owner}/${context.repo.repo} in:body "seed-uid:${uid}" type:issue`;
               const res = await github.rest.search.issuesAndPullRequests({ q });
               return res.data.items.find(i => !i.pull_request) || null;
             }
 
-            const created = JSON.parse(core.getInput('created'));
+            const created = JSON.parse(process.env.CREATED || '[]');
             const byUid = Object.fromEntries(created.map(i => [i.uid, i]));
 
-            // 1) Newly created epics: write Children checklist once
+            // 1) Newly created epics → write Children checklist once
             for (const item of created) {
               const meta = item.meta || {};
               const children = meta.children_uids || [];
@@ -244,7 +222,7 @@ jobs:
               core.info(`Epic #${item.number}: wrote initial Children list`);
             }
 
-            // 2) Newly created children: append to existing epic (idempotent)
+            // 2) Newly created children → append to existing epic (idempotent)
             for (const item of created) {
               const meta = item.meta || {};
               const parentUid = meta.parent_uid;
@@ -269,8 +247,7 @@ jobs:
                   (m, list) => `## Children\n${list || ""}${line}\n`
                 );
               } else {
-                // already linked
-                continue;
+                continue; // already linked
               }
 
               await github.rest.issues.update({
@@ -278,15 +255,16 @@ jobs:
               });
               core.info(`Linked child #${item.number} under epic #${parent.number}`);
             }
-          created: ${{ steps.create.outputs.created }}
 
-      - name: Open PR to consume processed seeds (pending → applied)
+      - name: Move processed seeds (pending → applied) and open PR if allowed
         if: steps.list.outputs.files != ''
         uses: actions/github-script@v7
+        env:
+          FILES: ${{ steps.list.outputs.files }}
         with:
           script: |
             const { execSync } = require('child_process');
-            const files = core.getInput('files').split(',').filter(Boolean);
+            const files = (process.env.FILES || '').split(',').filter(Boolean);
             if (!files.length) { core.info('No seeds to consume'); return; }
 
             const branch = `automation/consume-seeds-${Date.now()}`;
@@ -304,11 +282,20 @@ jobs:
             execSync('git commit -m "chore(automation): consume processed seeds → applied/"');
             execSync(`git push --set-upstream origin ${branch}`);
 
-            const pr = await github.rest.pulls.create({
-              owner: context.repo.owner, repo: context.repo.repo,
-              head: branch, base: 'main',
-              title: 'chore(automation): consume processed seeds → applied/',
-              body: 'Move processed seeds from pending/ to applied/ to enforce create-only snapshots.'
-            });
-            core.notice(`Opened consume PR #${pr.data.number}`);
-          files: ${{ steps.list.outputs.files }}
+            // Try to open PR; fall back to a console notice if blocked by org policy
+            try {
+              const pr = await github.rest.pulls.create({
+                owner: context.repo.owner, repo: context.repo.repo,
+                head: branch, base: 'main',
+                title: 'chore(automation): consume processed seeds → applied/',
+                body: 'Move processed seeds from pending/ to applied/ to enforce create-only snapshots.'
+              });
+              core.notice(`Opened consume PR #${pr.data.number}`);
+            } catch (e) {
+              if (e.status === 403 && /not permitted to create or approve pull requests/i.test(e.message)) {
+                const url = `https://github.com/${context.repo.owner}/${context.repo.repo}/compare/main...${encodeURIComponent(branch)}?expand=1`;
+                core.warning('Policy blocks Actions from creating PRs. Please open it manually: ' + url);
+              } else {
+                throw e;
+              }
+            }

--- a/.github/workflows/seed-project-items.yml
+++ b/.github/workflows/seed-project-items.yml
@@ -165,19 +165,34 @@ jobs:
 
             core.setOutput('created', JSON.stringify(created));
 
-      # Only wire parent/children on epics CREATED in this run (no rewrites)
-      - name: Wire parent/children on newly created epics
+            # Wire relationships without violating create-only:
+      # 1) If an EPIC was created in this run AND it declares children_uids → write its checklist now.
+      # 2) If a CHILD was created in this run AND declares parent_uid → append one checklist line to the existing epic (idempotent).
+      - name: Wire hierarchy (epic checklists + new child → existing epic)
         if: steps.create.outputs.created != ''
         uses: actions/github-script@v7
         with:
           script: |
             const core = require('@actions/core');
             const created = JSON.parse(core.getInput('created'));
+
+            // utility: find an issue by 'seed-uid:...' marker
+            async function findIssueByUid(uid) {
+              const q = `repo:${context.repo.owner}/${context.repo.repo} in:body "seed-uid:${uid}" type:issue`;
+              const res = await github.rest.search.issuesAndPullRequests({ q });
+              return res.data.items.find(i => !i.pull_request) || null;
+            }
+
             const byUid = Object.fromEntries(created.map(i => [i.uid, i]));
+
+            // 1) Newly created epics: write their Children checklist (only once).
             for (const item of created) {
               const meta = item.meta || {};
               const children = meta.children_uids || [];
               if (!children.length) continue;
+
+              // Only when epic itself was created in this run
+              if (!item.createdNew) continue;
 
               const childNums = children.map(u => byUid[u]?.number).filter(Boolean);
               if (!childNums.length) continue;
@@ -193,6 +208,46 @@ jobs:
               await github.rest.issues.update({
                 owner: context.repo.owner, repo: context.repo.repo,
                 issue_number: item.number, body
+              });
+            }
+
+            // 2) Newly created children: append to existing epic by parent_uid (idempotent).
+            for (const item of created) {
+              const meta = item.meta || {};
+              const parentUid = meta.parent_uid;
+              if (!parentUid) continue;
+
+              // find the epic by UID
+              const parent = await findIssueByUid(parentUid);
+              if (!parent) {
+                core.warning(`Child #${item.number} declares parent_uid=${parentUid} but no epic found.`);
+                continue;
+              }
+
+              // fetch current body to check duplication
+              const parentIssue = await github.rest.issues.get({
+                owner: context.repo.owner, repo: context.repo.repo, issue_number: parent.number
+              });
+
+              const line = `- [ ] #${item.number}`;
+              const header = "## Children";
+              let body = parentIssue.data.body || "";
+
+              // ensure header exists
+              if (!body.includes(header)) {
+                body = `${body}\n\n${header}\n${line}\n`;
+              } else if (!body.includes(line)) {
+                // insert line just after header or append to the existing list
+                body = body.replace(/## Children[^\n]*\n((?:- \[ \] #[0-9]+\n)*)/m, (m, list) => {
+                  return `## Children\n${list || ""}${line}\n`;
+                });
+              } else {
+                continue; // already linked; skip
+              }
+
+              await github.rest.issues.update({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: parent.number, body
               });
             }
           created: ${{ steps.create.outputs.created }}

--- a/.github/workflows/seed-project-items.yml
+++ b/.github/workflows/seed-project-items.yml
@@ -7,10 +7,10 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write            # needed for the auto "consume seeds" PR branch
+  contents: write            # needed to open the consume-seeds PR
   issues: write
   pull-requests: write
-  repository-projects: write # (optional) ok with schema; not strictly required for Project v2 GraphQL
+  repository-projects: write # optional; GraphQL to Projects V2 usually works without it
 
 concurrency:
   group: seed-${{ github.ref }}
@@ -32,13 +32,17 @@ jobs:
             git diff --name-only ${{ github.sha }}^ ${{ github.sha }} | grep -E "^\.github/project-seeds/pending/.*\.md$" || true > seeds.txt
           fi
           echo "files=$(paste -sd, seeds.txt)" >> "$GITHUB_OUTPUT"
-          echo "Seeds:"
-          cat seeds.txt || true
+          echo "Seeds:"; cat seeds.txt || true
 
-      - name: Create / update issues and add to Project
+      # ▶ CREATE-ONLY: if an issue with this UID already exists, SKIP.
+      - name: Create issues (create-only) and add to Project
         if: steps.list.outputs.files != ''
         id: create
         uses: actions/github-script@v7
+        env:
+          DEFAULT_PROJECT_URL: ${{ vars.PROJECT_URL }}       # repo Variable
+          DEFAULT_ASSIGNEE:     ${{ vars.DEFAULT_ASSIGNEE }} # repo Variable (may be empty)
+          FALLBACK_ASSIGNEE:    ${{ github.actor }}          # last resort
         with:
           script: |
             const core = require('@actions/core');
@@ -46,10 +50,9 @@ jobs:
             const path = require('path');
 
             const files = core.getInput('files').split(',').filter(Boolean);
-            const created = []; // {number, id, uid, title, meta, createdNew}
-            if (!files.length) { core.info('No seeds'); core.setOutput('created','[]'); return; }
+            if (!files.length) { core.setOutput('created','[]'); return; }
 
-            // Helper: parse header block
+            // Helpers
             function parseHeader(body) {
               const m = body.match(/<!--([\s\S]*?)-->/);
               if (!m) return { meta:{}, rest: body.trim() };
@@ -58,8 +61,7 @@ jobs:
               hdr.split('\n').forEach(line => {
                 const L = line.trim();
                 if (!L || L.startsWith('#')) return;
-                const idx = L.indexOf(':');
-                if (idx < 0) return;
+                const idx = L.indexOf(':'); if (idx < 0) return;
                 const k = L.slice(0, idx).trim();
                 let v = L.slice(idx+1).trim();
                 try { meta[k] = JSON.parse(v); }
@@ -68,110 +70,102 @@ jobs:
               const rest = body.replace(m[0], '').trim();
               return { meta, rest };
             }
-
-            // For Project v2 add, we need project id (from org + number)
+            async function findIssueByUid(uid) {
+              const q = `repo:${context.repo.owner}/${context.repo.repo} in:body "seed-uid:${uid}" type:issue`;
+              const res = await github.rest.search.issuesAndPullRequests({ q });
+              return res.data.items.find(i => !i.pull_request) || null;
+            }
             async function getProjectInfo(projectUrl) {
               const m = projectUrl?.match(/orgs\/([^/]+)\/projects\/(\d+)/);
               if (!m) return null;
               const [_, org, number] = m;
               const data = await github.graphql(`
                 query($org:String!, $num:Int!) {
-                  organization(login:$org){
-                    projectV2(number:$num){ id }
-                  }
+                  organization(login:$org){ projectV2(number:$num){ id } }
                 }`, { org, num: parseInt(number,10) });
-              return { org, number: parseInt(number,10), projectId: data.organization.projectV2.id };
+              return { projectId: data.organization.projectV2.id };
             }
-
-            // Add an Issue to Project v2
-            async function addIssueToProject(projectId, issueNodeId) {
+            async function addIssueToProject(projectId, issueNumber) {
+              const node = await github.graphql(`
+                query($o:String!, $r:String!, $n:Int!){
+                  repository(owner:$o, name:$r){ issue(number:$n){ id } }
+                }`, { o: context.repo.owner, r: context.repo.repo, n: issueNumber });
               await github.graphql(`
                 mutation($projectId:ID!, $contentId:ID!){
                   addProjectV2ItemById(input:{projectId:$projectId, contentId:$contentId}){ item { id } }
-                }`, { projectId, contentId: issueNodeId });
+                }`, { projectId, contentId: node.repository.issue.id });
             }
 
-            // Search existing by uid marker
-            async function findIssueByUid(uid) {
-              const q = `repo:${context.repo.owner}/${context.repo.repo} in:body "seed-uid:${uid}" type:issue`;
-              const res = await github.rest.search.issuesAndPullRequests({ q });
-              return res.data.items.find(i => !i.pull_request) || null;
-            }
+            const DEFAULT_PROJECT_URL = process.env.DEFAULT_PROJECT_URL || null;
+            const DEFAULT_ASSIGNEE = process.env.DEFAULT_ASSIGNEE || '';
+            const FALLBACK_ASSIGNEE = process.env.FALLBACK_ASSIGNEE || '';
 
-            // Preload project once (use first seed's project_url)
-            let projectInfo = null;
+            let projectInfo = null; // single Project for all seeds (by design)
 
+            const created = []; // [{number, uid, meta, createdNew:true}]
             for (const f of files) {
               const raw = fs.readFileSync(f, 'utf8');
               const { meta, rest } = parseHeader(raw);
+
               const title = meta.title || path.basename(f);
               const labels = Array.isArray(meta.labels) ? meta.labels : (meta.labels ? [meta.labels] : []);
-              const assignees = Array.isArray(meta.assignees) ? meta.assignees : (meta.assignees ? [meta.assignees] : []);
               const uid = meta.uid || null;
-              const projectUrl = meta.project_url || null;
 
-              // default to create-only snapshot semantics
-              const mode = (meta.mode ?? 'create_only').toString();
+              // create-only defaults (hard)
+              const mode = (meta.mode ?? 'create_only') + '';
               const frozen = String(meta.frozen ?? 'true') === 'true';
-              const lifecycle = (meta.lifecycle ?? 'seed_only').toString();
+              const lifecycle = (meta.lifecycle ?? 'seed_only') + '';
               const createOnly = (mode === 'create_only') || frozen || (lifecycle === 'seed_only');
 
-              // body with hidden uid marker
-              const issueBody = `${rest}\n\n<!-- seed-uid:${uid || 'none'} -->`.trim();
-
-              let existing = null;
-              if (uid) existing = await findIssueByUid(uid);
-
-              let issue, createdNew = false;
-              if (existing && createOnly) {
-                core.info(`Seed ${uid}: issue #${existing.number} exists; create-only → skipping update`);
-                // fetch full issue to get node id later
-                issue = (await github.rest.issues.get({
-                  owner: context.repo.owner, repo: context.repo.repo, issue_number: existing.number
-                })).data;
-              } else if (existing) {
-                core.info(`Seed ${uid}: updating issue #${existing.number}`);
-                issue = (await github.rest.issues.update({
-                  owner: context.repo.owner, repo: context.repo.repo,
-                  issue_number: existing.number, title, body: issueBody
-                })).data;
-                if (labels.length) {
-                  await github.rest.issues.addLabels({ owner: context.repo.owner, repo: context.repo.repo, issue_number: existing.number, labels });
-                }
-                if (assignees.length) {
-                  await github.rest.issues.addAssignees({ owner: context.repo.owner, repo: context.repo.repo, issue_number: existing.number, assignees });
-                }
-              } else {
-                core.info(`Seed ${uid || title}: creating new issue`);
-                issue = (await github.rest.issues.create({
-                  owner: context.repo.owner, repo: context.repo.repo,
-                  title, body: issueBody, labels, assignees
-                })).data;
-                createdNew = true;
+              if (!uid) {
+                core.warning(`Seed ${f} missing 'uid'; skipping.`);
+                continue;
               }
 
-              // Add to Project
+              // If an issue with this UID already exists → SKIP (create-only)
+              const existing = await findIssueByUid(uid);
+              if (existing && createOnly) {
+                core.info(`Seed ${uid}: issue #${existing.number} exists → create-only SKIP`);
+                continue;
+              }
+
+              // assignees: seed > DEFAULT_ASSIGNEE > actor > none
+              let assignees = [];
+              if (Array.isArray(meta.assignees)) assignees = meta.assignees;
+              else if (meta.assignees) assignees = [meta.assignees];
+              else if (DEFAULT_ASSIGNEE) assignees = [DEFAULT_ASSIGNEE];
+              else if (FALLBACK_ASSIGNEE) assignees = [FALLBACK_ASSIGNEE];
+
+              // project URL: seed value, else repo default, else no add
+              const projectUrl = meta.project_url || DEFAULT_PROJECT_URL || null;
+
+              const body = `${rest}\n\n<!-- seed-uid:${uid} -->`.trim();
+
+              // CREATE
+              const issue = (await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels,
+                assignees
+              })).data;
+
+              // add to Project (optional)
               if (projectUrl) {
                 if (!projectInfo) projectInfo = await getProjectInfo(projectUrl);
                 if (projectInfo?.projectId) {
-                  // fetch node id for the issue
-                  const nodeQ = await github.graphql(`
-                    query($o:String!, $r:String!, $n:Int!){
-                      repository(owner:$o, name:$r){ issue(number:$n){ id } }
-                    }`,
-                    { o: context.repo.owner, r: context.repo.repo, n: issue.number }
-                  );
-                  await addIssueToProject(projectInfo.projectId, nodeQ.repository.issue.id).catch(e => core.warning(`Add to project failed for #${issue.number}: ${e.message}`));
+                  await addIssueToProject(projectInfo.projectId, issue.number)
+                    .catch(e => core.warning(`Add to project failed for #${issue.number}: ${e.message}`));
                 }
               }
 
-              created.push({ number: issue.number, id: issue.id, uid, title, meta, createdNew });
+              created.push({ number: issue.number, uid, meta, createdNew: true });
             }
 
             core.setOutput('created', JSON.stringify(created));
-          result-encoding: string
-          files: ${{ steps.list.outputs.files }}
 
+      # Only wire parent/children on epics CREATED in this run (no rewrites)
       - name: Wire parent/children on newly created epics
         if: steps.create.outputs.created != ''
         uses: actions/github-script@v7
@@ -184,14 +178,10 @@ jobs:
               const meta = item.meta || {};
               const children = meta.children_uids || [];
               if (!children.length) continue;
-              // Only inject checklist when epic was created now (avoid rewriting snapshots)
-              if (!item.createdNew) continue;
 
-              // Compose checklist
               const childNums = children.map(u => byUid[u]?.number).filter(Boolean);
               if (!childNums.length) continue;
 
-              // Fetch current body
               const issue = await github.rest.issues.get({
                 owner: context.repo.owner, repo: context.repo.repo, issue_number: item.number
               });
@@ -222,17 +212,14 @@ jobs:
             execSync('git config user.name "github-actions[bot]"');
             execSync('git config user.email "41898282+github-actions[bot]@users.noreply.github.com"');
             execSync(`git checkout -b ${branch}`);
-
             for (const f of files) {
               const target = f.replace('/pending/', '/applied/');
               execSync(`mkdir -p "$(dirname "${target}")"`);
               execSync(`git mv "${f}" "${target}"`);
             }
-
             execSync('git add -A');
             execSync('git commit -m "chore(automation): consume processed seeds → applied/"');
             execSync(`git push --set-upstream origin ${branch}`);
-
             const pr = await github.rest.pulls.create({
               owner: context.repo.owner, repo: context.repo.repo,
               head: branch, base: 'main',

--- a/.github/workflows/seed-project-items.yml
+++ b/.github/workflows/seed-project-items.yml
@@ -6,11 +6,12 @@ on:
       - ".github/project-seeds/pending/**.md"
   workflow_dispatch:
 
+# GITHUB_TOKEN perms needed for issues, PR, and repo-projects (Project v2 via GraphQL)
 permissions:
-  contents: write            # needed to open the consume-seeds PR
+  contents: write
   issues: write
   pull-requests: write
-  repository-projects: write # optional; GraphQL to Projects V2 usually works without it
+  repository-projects: write
 
 concurrency:
   group: seed-${{ github.ref }}
@@ -25,112 +26,141 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: List pending seed files (robust on first push & shallow clones)
+      - name: List pending seed files (robust on first push & shallow diffs)
         id: list
+        shell: bash
         run: |
           set -euo pipefail
           BEFORE="${{ github.event.before }}"
           AFTER="${{ github.sha }}"
           SEED_GLOB=".github/project-seeds/pending/**.md"
 
-          # First push to a branch often has BEFORE all zeros or unset.
           if [ -z "${BEFORE}" ] || [ "${BEFORE}" = "0000000000000000000000000000000000000000" ]; then
-            # List all tracked seeds in pending/
+            # First push to branch (no parent) → list all tracked seeds
             git ls-files "${SEED_GLOB}" > seeds.txt || true
           else
-            # Only files touched in this push → group the pipeline, then redirect once
+            # Only files touched in this push → group pipeline, redirect once
             ( git diff --name-only "${BEFORE}" "${AFTER}" \
               | grep -E "^\.github/project-seeds/pending/.*\.md$" || true ) > seeds.txt
           fi
 
           echo "files=$(paste -sd, seeds.txt)" >> "$GITHUB_OUTPUT"
-          echo "Seeds:"; cat seeds.txt || true
+          echo "Seeds to process:"
+          cat seeds.txt || true
 
-      # ▶ CREATE-ONLY: if an issue with this UID already exists, SKIP.
       - name: Create issues (create-only) and add to Project
         if: steps.list.outputs.files != ''
         id: create
         uses: actions/github-script@v7
         env:
-          DEFAULT_PROJECT_URL: ${{ vars.PROJECT_URL }}       # repo Variable
-          DEFAULT_ASSIGNEE:     ${{ vars.DEFAULT_ASSIGNEE }} # repo Variable (may be empty)
-          FALLBACK_ASSIGNEE:    ${{ github.actor }}          # last resort
+          # Prefer repo-level variables over hard-coding
+          DEFAULT_PROJECT_URL: ${{ vars.PROJECT_URL }}
+          DEFAULT_ASSIGNEE:     ${{ vars.DEFAULT_ASSIGNEE }}
+          FALLBACK_ASSIGNEE:    ${{ github.actor }}
         with:
           script: |
-            // NOTE: actions/github-script injects 'core' and 'github' globals — no need to require('@actions/core')
+            // actions/github-script provides 'core', 'github', and 'context' globals.
             const fs = require('fs');
             const path = require('path');
 
             const files = core.getInput('files').split(',').filter(Boolean);
             if (!files.length) { core.setOutput('created','[]'); return; }
 
-            // Helpers
+            // --- helpers -----------------------------------------------------
             function parseHeader(body) {
+              // Header block is an HTML comment at the top of the seed file.
               const m = body.match(/<!--([\s\S]*?)-->/);
               if (!m) return { meta:{}, rest: body.trim() };
               const hdr = m[1];
               const meta = {};
               hdr.split('\n').forEach(line => {
                 const L = line.trim();
-                if (!L || L.startsWith('#')) return;
-                const idx = L.indexOf(':'); if (idx < 0) return;
+                if (!L || L.startsWith('#')) return;          // ignore yaml-style notes in header
+                const idx = L.indexOf(':');
+                if (idx < 0) return;
                 const k = L.slice(0, idx).trim();
                 let v = L.slice(idx+1).trim();
+                // allow JSON or plain strings
                 try { meta[k] = JSON.parse(v); }
                 catch { meta[k] = v.replace(/^"+|"+$/g,''); }
               });
               const rest = body.replace(m[0], '').trim();
               return { meta, rest };
             }
+
             async function findIssueByUid(uid) {
               const q = `repo:${context.repo.owner}/${context.repo.repo} in:body "seed-uid:${uid}" type:issue`;
               const res = await github.rest.search.issuesAndPullRequests({ q });
+              // Only issues, not PRs
               return res.data.items.find(i => !i.pull_request) || null;
             }
+
             async function getProjectInfo(projectUrl) {
-              const m = projectUrl?.match(/orgs\/([^/]+)\/projects\/(\d+)/) || projectUrl?.match(/users\/([^/]+)\/projects\/(\d+)/);
-              if (!m) return null;
-              const isOrg = projectUrl.includes('/orgs/');
-              const login = m[1];
-              const number = parseInt(m[2],10);
-              if (isOrg) {
-                const data = await github.graphql(`query($org:String!, $num:Int!){ organization(login:$org){ projectV2(number:$num){ id } } }`, { org: login, num: number });
+              // Accept both org and user Projects v2:
+              // - https://github.com/orgs/ORG/projects/123
+              // - https://github.com/users/USER/projects/1
+              const orgMatch  = projectUrl?.match(/orgs\/([^/]+)\/projects\/(\d+)/);
+              const userMatch = projectUrl?.match(/users\/([^/]+)\/projects\/(\d+)/);
+              if (!orgMatch && !userMatch) return null;
+
+              if (orgMatch) {
+                const [_, org, n] = orgMatch;
+                const number = parseInt(n, 10);
+                const data = await github.graphql(
+                  `query($org:String!, $num:Int!){
+                    organization(login:$org){ projectV2(number:$num){ id } }
+                  }`,
+                  { org, num: number }
+                );
                 return { projectId: data.organization.projectV2.id };
               } else {
-                const data = await github.graphql(`query($user:String!, $num:Int!){ user(login:$user){ projectV2(number:$num){ id } } }`, { user: login, num: number });
+                const [_, user, n] = userMatch;
+                const number = parseInt(n, 10);
+                const data = await github.graphql(
+                  `query($user:String!, $num:Int!){
+                    user(login:$user){ projectV2(number:$num){ id } }
+                  }`,
+                  { user, num: number }
+                );
                 return { projectId: data.user.projectV2.id };
               }
             }
+
             async function addIssueToProject(projectId, issueNumber) {
               const node = await github.graphql(
-                `query($o:String!, $r:String!, $n:Int!){ repository(owner:$o, name:$r){ issue(number:$n){ id } } }`,
+                `query($o:String!, $r:String!, $n:Int!){
+                  repository(owner:$o, name:$r){ issue(number:$n){ id } }
+                }`,
                 { o: context.repo.owner, r: context.repo.repo, n: issueNumber }
               );
               await github.graphql(
-                `mutation($projectId:ID!, $contentId:ID!){ addProjectV2ItemById(input:{projectId:$projectId, contentId:$contentId}){ item { id } } }`,
+                `mutation($projectId:ID!, $contentId:ID!){
+                  addProjectV2ItemById(input:{projectId:$projectId, contentId:$contentId}){ item { id } }
+                }`,
                 { projectId, contentId: node.repository.issue.id }
               );
             }
+            // -----------------------------------------------------------------
 
             const DEFAULT_PROJECT_URL = process.env.DEFAULT_PROJECT_URL || null;
-            const DEFAULT_ASSIGNEE = process.env.DEFAULT_ASSIGNEE || '';
-            const FALLBACK_ASSIGNEE = process.env.FALLBACK_ASSIGNEE || '';
+            const DEFAULT_ASSIGNEE    = process.env.DEFAULT_ASSIGNEE || '';
+            const FALLBACK_ASSIGNEE   = process.env.FALLBACK_ASSIGNEE || '';
 
-            let projectInfo = null;
-            const created = [];
+            let projectInfo = null; // one project for all seeds by design
+            const created = [];      // [{ number, uid, meta, createdNew: true }]
 
             for (const f of files) {
               const raw = fs.readFileSync(f, 'utf8');
               const { meta, rest } = parseHeader(raw);
 
-              const title = meta.title || path.basename(f);
+              const title  = meta.title || path.basename(f);
               const labels = Array.isArray(meta.labels) ? meta.labels : (meta.labels ? [meta.labels] : []);
-              const uid = meta.uid || null;
+              const uid    = meta.uid || null;
 
-              // create-only defaults (hard)
-              const mode = (meta.mode ?? 'create_only') + '';
-              const frozen = String(meta.frozen ?? 'true') === 'true';
-              const lifecycle = (meta.lifecycle ?? 'seed_only') + '';
+              // Hard "create-only" semantics unless seed says otherwise
+              const mode      = String(meta.mode ?? 'create_only');
+              const frozen    = String(meta.frozen ?? 'true') === 'true';
+              const lifecycle = String(meta.lifecycle ?? 'seed_only');
               const createOnly = (mode === 'create_only') || frozen || (lifecycle === 'seed_only');
 
               if (!uid) {
@@ -138,35 +168,30 @@ jobs:
                 continue;
               }
 
-              // If an issue with this UID already exists → SKIP (create-only)
               const existing = await findIssueByUid(uid);
               if (existing && createOnly) {
                 core.info(`Seed ${uid}: issue #${existing.number} exists → create-only SKIP`);
                 continue;
               }
 
-              // assignees: seed > DEFAULT_ASSIGNEE > actor > none
+              // Assignees: seed > default var > actor > none
               let assignees = [];
               if (Array.isArray(meta.assignees)) assignees = meta.assignees;
-              else if (meta.assignees) assignees = [meta.assignees];
-              else if (DEFAULT_ASSIGNEE) assignees = [DEFAULT_ASSIGNEE];
-              else if (FALLBACK_ASSIGNEE) assignees = [FALLBACK_ASSIGNEE];
+              else if (meta.assignees)           assignees = [meta.assignees];
+              else if (DEFAULT_ASSIGNEE)         assignees = [DEFAULT_ASSIGNEE];
+              else if (FALLBACK_ASSIGNEE)        assignees = [FALLBACK_ASSIGNEE];
 
-              // project URL: seed value, else repo default, else no add
               const projectUrl = meta.project_url || DEFAULT_PROJECT_URL || null;
               const body = `${rest}\n\n<!-- seed-uid:${uid} -->`.trim();
 
               // CREATE
               const issue = (await github.rest.issues.create({
                 owner: context.repo.owner,
-                repo: context.repo.repo,
-                title,
-                body,
-                labels,
-                assignees
+                repo:  context.repo.repo,
+                title, body, labels, assignees
               })).data;
 
-              // add to Project (optional)
+              // Add to Project (optional)
               if (projectUrl) {
                 if (!projectInfo) projectInfo = await getProjectInfo(projectUrl);
                 if (projectInfo?.projectId) {
@@ -176,20 +201,17 @@ jobs:
               }
 
               created.push({ number: issue.number, uid, meta, createdNew: true });
+              core.info(`Created issue #${issue.number} for seed ${uid}`);
             }
 
             core.setOutput('created', JSON.stringify(created));
 
-            # Wire relationships without violating create-only:
-      # 1) If an EPIC was created in this run AND it declares children_uids → write its checklist now.
-      # 2) If a CHILD was created in this run AND declares parent_uid → append one checklist line to the existing epic (idempotent).
-      - name: Wire hierarchy (epic checklists + new child → existing epic)
+      - name: Wire hierarchy (epic checklists and late child → existing epic)
         if: steps.create.outputs.created != ''
         uses: actions/github-script@v7
         with:
           script: |
-            // 'core' and 'github' are provided
-            // utility: find an issue by 'seed-uid:...' marker
+            // 'core', 'github', 'context' provided by actions/github-script
             async function findIssueByUid(uid) {
               const q = `repo:${context.repo.owner}/${context.repo.repo} in:body "seed-uid:${uid}" type:issue`;
               const res = await github.rest.search.issuesAndPullRequests({ q });
@@ -199,14 +221,11 @@ jobs:
             const created = JSON.parse(core.getInput('created'));
             const byUid = Object.fromEntries(created.map(i => [i.uid, i]));
 
-            // 1) Newly created epics: write their Children checklist (only once).
+            // 1) Newly created epics: write Children checklist once
             for (const item of created) {
               const meta = item.meta || {};
               const children = meta.children_uids || [];
-              if (!children.length) continue;
-
-              // Only when epic itself was created in this run
-              if (!item.createdNew) continue;
+              if (!children.length || !item.createdNew) continue;
 
               const childNums = children.map(u => byUid[u]?.number).filter(Boolean);
               if (!childNums.length) continue;
@@ -220,39 +239,44 @@ jobs:
               const body = `${issue.data.body}\n\n${header}${list}\n`;
 
               await github.rest.issues.update({
-                owner: context.repo.owner, repo: context.repo.repo,
-                issue_number: item.number, body
+                owner: context.repo.owner, repo: context.repo.repo, issue_number: item.number, body
               });
+              core.info(`Epic #${item.number}: wrote initial Children list`);
             }
 
-            // 2) Newly created children: append to existing epic by parent_uid (idempotent).
+            // 2) Newly created children: append to existing epic (idempotent)
             for (const item of created) {
               const meta = item.meta || {};
               const parentUid = meta.parent_uid;
               if (!parentUid) continue;
 
-              // find the epic by UID
               const parent = await findIssueByUid(parentUid);
-              if (!parent) { core.warning(`Child #${item.number} parent_uid=${parentUid} not found`); continue; }
+              if (!parent) { core.warning(`Child #${item.number}: parent_uid=${parentUid} not found`); continue; }
 
-              // fetch current body to check duplication
-              const parentIssue = await github.rest.issues.get({ owner: context.repo.owner, repo: context.repo.repo, issue_number: parent.number });
+              const parentIssue = await github.rest.issues.get({
+                owner: context.repo.owner, repo: context.repo.repo, issue_number: parent.number
+              });
 
               const line = `- [ ] #${item.number}`;
               const header = "## Children";
               let body = parentIssue.data.body || "";
 
-              // ensure header exists
               if (!body.includes(header)) {
                 body = `${body}\n\n${header}\n${line}\n`;
               } else if (!body.includes(line)) {
-                // insert line just after header or append to the existing list
-              body = body.replace(/## Children[^\n]*\n((?:- \[ \] #[0-9]+\n)*)/m, (m, list) => `## Children\n${list || ""}${line}\n`);
+                body = body.replace(
+                  /## Children[^\n]*\n((?:- \[ \] #[0-9]+\n)*)/m,
+                  (m, list) => `## Children\n${list || ""}${line}\n`
+                );
               } else {
+                // already linked
                 continue;
               }
 
-              await github.rest.issues.update({ owner: context.repo.owner, repo: context.repo.repo, issue_number: parent.number, body });
+              await github.rest.issues.update({
+                owner: context.repo.owner, repo: context.repo.repo, issue_number: parent.number, body
+              });
+              core.info(`Linked child #${item.number} under epic #${parent.number}`);
             }
           created: ${{ steps.create.outputs.created }}
 
@@ -269,14 +293,17 @@ jobs:
             execSync('git config user.name "github-actions[bot]"');
             execSync('git config user.email "41898282+github-actions[bot]@users.noreply.github.com"');
             execSync(`git checkout -b ${branch}`);
+
             for (const f of files) {
               const target = f.replace('/pending/', '/applied/');
               execSync(`mkdir -p "$(dirname "${target}")"`);
               execSync(`git mv "${f}" "${target}"`);
             }
+
             execSync('git add -A');
             execSync('git commit -m "chore(automation): consume processed seeds → applied/"');
             execSync(`git push --set-upstream origin ${branch}`);
+
             const pr = await github.rest.pulls.create({
               owner: context.repo.owner, repo: context.repo.repo,
               head: branch, base: 'main',

--- a/.github/workflows/seed-project-items.yml
+++ b/.github/workflows/seed-project-items.yml
@@ -7,10 +7,10 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write           # needed for the auto "consume seeds" PR
+  contents: write            # needed for the auto "consume seeds" PR branch
   issues: write
   pull-requests: write
-  projects: write
+  repository-projects: write # (optional) ok with schema; not strictly required for Project v2 GraphQL
 
 concurrency:
   group: seed-${{ github.ref }}
@@ -98,7 +98,6 @@ jobs:
               return res.data.items.find(i => !i.pull_request) || null;
             }
 
-            const results = [];
             // Preload project once (use first seed's project_url)
             let projectInfo = null;
 
@@ -127,7 +126,9 @@ jobs:
               if (existing && createOnly) {
                 core.info(`Seed ${uid}: issue #${existing.number} exists; create-only → skipping update`);
                 // fetch full issue to get node id later
-                issue = (await github.rest.issues.get({ owner: context.repo.owner, repo: context.repo.repo, issue_number: existing.number })).data;
+                issue = (await github.rest.issues.get({
+                  owner: context.repo.owner, repo: context.repo.repo, issue_number: existing.number
+                })).data;
               } else if (existing) {
                 core.info(`Seed ${uid}: updating issue #${existing.number}`);
                 issue = (await github.rest.issues.update({
@@ -164,10 +165,12 @@ jobs:
                 }
               }
 
-              results.push({ number: issue.number, id: issue.id, uid, title, meta, createdNew });
+              created.push({ number: issue.number, id: issue.id, uid, title, meta, createdNew });
             }
 
-            core.setOutput('created', JSON.stringify(results));
+            core.setOutput('created', JSON.stringify(created));
+          result-encoding: string
+          files: ${{ steps.list.outputs.files }}
 
       - name: Wire parent/children on newly created epics
         if: steps.create.outputs.created != ''
@@ -202,8 +205,7 @@ jobs:
                 issue_number: item.number, body
               });
             }
-          with:
-            created: ${{ steps.create.outputs.created }}
+          created: ${{ steps.create.outputs.created }}
 
       - name: Open PR to consume processed seeds (pending → applied)
         if: steps.list.outputs.files != ''
@@ -238,5 +240,4 @@ jobs:
               body: 'Move processed seeds from pending/ to applied/ to enforce create-only snapshots.'
             });
             core.notice(`Opened consume PR #${pr.data.number}`);
-        with:
           files: ${{ steps.list.outputs.files }}

--- a/.github/workflows/seed-project-items.yml
+++ b/.github/workflows/seed-project-items.yml
@@ -52,18 +52,24 @@ jobs:
         uses: actions/github-script@v7
         env:
           FILES:                ${{ steps.list.outputs.files }}
+          # Prefer PROJECT_ID if you have it (GraphQL node id like "PVT_xxx")
+          PROJECT_ID:           ${{ vars.PROJECT_ID }}
+          # Otherwise, keep using a human URL; make sure it's a **Projects v2** URL:
+          #   - user scope: https://github.com/users/<user>/projects/<n>
+          #   - org  scope: https://github.com/orgs/<org>/projects/<n>
           DEFAULT_PROJECT_URL:  ${{ vars.PROJECT_URL }}
           DEFAULT_ASSIGNEE:     ${{ vars.DEFAULT_ASSIGNEE }}
           FALLBACK_ASSIGNEE:    ${{ github.actor }}
         with:
           script: |
-            // 'core', 'github', 'context' are provided
+            // 'core', 'github', 'context' are provided by actions/github-script
             const fs = require('fs');
             const path = require('path');
 
             const files = (process.env.FILES || '').split(',').filter(Boolean);
             if (!files.length) { core.setOutput('created','[]'); return; }
 
+            // ---------- helpers ----------
             function parseHeader(body) {
               const m = body.match(/<!--([\s\S]*?)-->/);
               if (!m) return { meta:{}, rest: body.trim() };
@@ -88,49 +94,82 @@ jobs:
               return res.data.items.find(i => !i.pull_request) || null;
             }
 
-            async function getProjectInfo(projectUrl) {
-              const orgMatch  = projectUrl?.match(/orgs\/([^/]+)\/projects\/(\d+)/);
-              const userMatch = projectUrl?.match(/users\/([^/]+)\/projects\/(\d+)/);
-              if (!orgMatch && !userMatch) return null;
+            // ----- Projects v2 resolution (robust & non-fatal) -----
+            async function resolveProjectIdFromUrl(projectUrl) {
+              try {
+                if (!projectUrl) return null;
 
-              if (orgMatch) {
-                const [_, org, n] = orgMatch; const num = parseInt(n,10);
-                const data = await github.graphql(
-                  `query($org:String!, $num:Int!){
-                    organization(login:$org){ projectV2(number:$num){ id } }
-                  }`, { org, num }
-                );
-                return { projectId: data.organization.projectV2.id };
-              } else {
-                const [_, user, n] = userMatch; const num = parseInt(n,10);
-                const data = await github.graphql(
-                  `query($user:String!, $num:Int!){
-                    user(login:$user){ projectV2(number:$num){ id } }
-                  }`, { user, num }
-                );
-                return { projectId: data.user.projectV2.id };
+                const orgMatch  = projectUrl.match(/orgs\/([^/]+)\/projects\/(\d+)/);
+                const userMatch = projectUrl.match(/users\/([^/]+)\/projects\/(\d+)/);
+
+                if (orgMatch) {
+                  const [_, org, n] = orgMatch; const num = parseInt(n,10);
+                  const data = await github.graphql(
+                    `query($org:String!, $num:Int!){
+                      organization(login:$org){ projectV2(number:$num){ id } }
+                    }`, { org, num }
+                  );
+                  const id = data?.organization?.projectV2?.id || null;
+                  if (!id) core.warning(`Projects v2 not found at ${projectUrl} (org=${org}, number=${num}). Is this a classic project or the wrong number?`);
+                  return id;
+                }
+
+                if (userMatch) {
+                  const [_, user, n] = userMatch; const num = parseInt(n,10);
+                  const data = await github.graphql(
+                    `query($user:String!, $num:Int!){
+                      user(login:$user){ projectV2(number:$num){ id } }
+                    }`, { user, num }
+                  );
+                  const id = data?.user?.projectV2?.id || null;
+                  if (!id) core.warning(`Projects v2 not found at ${projectUrl} (user=${user}, number=${num}). Is this a classic project or the wrong number?`);
+                  return id;
+                }
+
+                core.warning(`Unrecognized project URL format: ${projectUrl}`);
+                return null;
+              } catch (e) {
+                core.warning(`Project lookup failed for ${projectUrl}: ${e.message}`);
+                return null; // non-fatal
               }
             }
 
             async function addIssueToProject(projectId, issueNumber) {
-              const node = await github.graphql(
-                `query($o:String!, $r:String!, $n:Int!){
-                  repository(owner:$o, name:$r){ issue(number:$n){ id } }
-                }`, { o: context.repo.owner, r: context.repo.repo, n: issueNumber }
-              );
-              await github.graphql(
-                `mutation($projectId:ID!, $contentId:ID!){
-                  addProjectV2ItemById(input:{projectId:$projectId, contentId:$contentId}){ item { id } }
-                }`, { projectId, contentId: node.repository.issue.id }
-              );
+              try {
+                if (!projectId) return; // nothing to do
+                const node = await github.graphql(
+                  `query($o:String!, $r:String!, $n:Int!){
+                    repository(owner:$o, name:$r){ issue(number:$n){ id } }
+                  }`, { o: context.repo.owner, r: context.repo.repo, n: issueNumber }
+                );
+                const contentId = node?.repository?.issue?.id;
+                if (!contentId) { core.warning(`Could not resolve content node id for issue #${issueNumber}`); return; }
+                await github.graphql(
+                  `mutation($projectId:ID!, $contentId:ID!){
+                    addProjectV2ItemById(input:{projectId:$projectId, contentId:$contentId}){ item { id } }
+                  }`, { projectId, contentId }
+                );
+              } catch (e) {
+                core.warning(`Add to project failed for #${issueNumber}: ${e.message}`);
+              }
             }
+            // ---------- /helpers ----------
 
             const DEFAULT_PROJECT_URL = process.env.DEFAULT_PROJECT_URL || null;
             const DEFAULT_ASSIGNEE    = process.env.DEFAULT_ASSIGNEE || '';
             const FALLBACK_ASSIGNEE   = process.env.FALLBACK_ASSIGNEE || '';
+            const PROJECT_ID_OVERRIDE = process.env.PROJECT_ID || '';
 
-            let projectInfo = null;
-            const created = [];
+            // Resolve the project **once** (non-fatal)
+            let projectId = PROJECT_ID_OVERRIDE || null;
+            if (!projectId && DEFAULT_PROJECT_URL) {
+              projectId = await resolveProjectIdFromUrl(DEFAULT_PROJECT_URL);
+            }
+            if (!projectId && DEFAULT_PROJECT_URL) {
+              core.warning(`Skipping "add to project": could not resolve Projects v2 from ${DEFAULT_PROJECT_URL}`);
+            }
+
+            const created = []; // [{ number, uid, meta, createdNew: true }]
 
             for (const f of files) {
               const raw = fs.readFileSync(f, 'utf8');
@@ -140,6 +179,7 @@ jobs:
               const labels = Array.isArray(meta.labels) ? meta.labels : (meta.labels ? [meta.labels] : []);
               const uid    = meta.uid || null;
 
+              // Create-only semantics by default
               const mode      = String(meta.mode ?? 'create_only');
               const frozen    = String(meta.frozen ?? 'true') === 'true';
               const lifecycle = String(meta.lifecycle ?? 'seed_only');
@@ -153,34 +193,34 @@ jobs:
                 continue;
               }
 
+              // Assignees: seed > default var > fallback
               let assignees = [];
               if (Array.isArray(meta.assignees)) assignees = meta.assignees;
               else if (meta.assignees)           assignees = [meta.assignees];
               else if (DEFAULT_ASSIGNEE)         assignees = [DEFAULT_ASSIGNEE];
               else if (FALLBACK_ASSIGNEE)        assignees = [FALLBACK_ASSIGNEE];
 
-              const projectUrl = meta.project_url || DEFAULT_PROJECT_URL || null;
               const body = `${rest}\n\n<!-- seed-uid:${uid} -->`.trim();
 
+              // CREATE (always continue on failure of project-add)
               const issue = (await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo:  context.repo.repo,
                 title, body, labels, assignees
               })).data;
 
-              if (projectUrl) {
-                if (!projectInfo) projectInfo = await getProjectInfo(projectUrl);
-                if (projectInfo?.projectId) {
-                  await addIssueToProject(projectInfo.projectId, issue.number)
-                    .catch(e => core.warning(`Add to project failed for #${issue.number}: ${e.message}`));
-                }
-              }
+              // Optional: add to project
+              const chosenProjectUrl = meta.project_url || DEFAULT_PROJECT_URL || null;
+              const chosenProjectId  = PROJECT_ID_OVERRIDE
+                                       || (chosenProjectUrl ? projectId : null);
+              await addIssueToProject(chosenProjectId, issue.number);
 
               created.push({ number: issue.number, uid, meta, createdNew: true });
               core.info(`Created issue #${issue.number} for seed ${uid}`);
             }
 
             core.setOutput('created', JSON.stringify(created));
+
 
       - name: Wire hierarchy (epic checklists + late child linking)
         if: steps.create.outputs.created != ''

--- a/.github/workflows/seed-project-items.yml
+++ b/.github/workflows/seed-project-items.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - name: List pending seed files (robust on first push & shallow clones)
         id: list
         run: |
@@ -56,7 +57,7 @@ jobs:
           FALLBACK_ASSIGNEE:    ${{ github.actor }}          # last resort
         with:
           script: |
-            const core = require('@actions/core');
+            // NOTE: actions/github-script injects 'core' and 'github' globals — no need to require('@actions/core')
             const fs = require('fs');
             const path = require('path');
 
@@ -87,33 +88,37 @@ jobs:
               return res.data.items.find(i => !i.pull_request) || null;
             }
             async function getProjectInfo(projectUrl) {
-              const m = projectUrl?.match(/orgs\/([^/]+)\/projects\/(\d+)/);
+              const m = projectUrl?.match(/orgs\/([^/]+)\/projects\/(\d+)/) || projectUrl?.match(/users\/([^/]+)\/projects\/(\d+)/);
               if (!m) return null;
-              const [_, org, number] = m;
-              const data = await github.graphql(`
-                query($org:String!, $num:Int!) {
-                  organization(login:$org){ projectV2(number:$num){ id } }
-                }`, { org, num: parseInt(number,10) });
-              return { projectId: data.organization.projectV2.id };
+              const isOrg = projectUrl.includes('/orgs/');
+              const login = m[1];
+              const number = parseInt(m[2],10);
+              if (isOrg) {
+                const data = await github.graphql(`query($org:String!, $num:Int!){ organization(login:$org){ projectV2(number:$num){ id } } }`, { org: login, num: number });
+                return { projectId: data.organization.projectV2.id };
+              } else {
+                const data = await github.graphql(`query($user:String!, $num:Int!){ user(login:$user){ projectV2(number:$num){ id } } }`, { user: login, num: number });
+                return { projectId: data.user.projectV2.id };
+              }
             }
             async function addIssueToProject(projectId, issueNumber) {
-              const node = await github.graphql(`
-                query($o:String!, $r:String!, $n:Int!){
-                  repository(owner:$o, name:$r){ issue(number:$n){ id } }
-                }`, { o: context.repo.owner, r: context.repo.repo, n: issueNumber });
-              await github.graphql(`
-                mutation($projectId:ID!, $contentId:ID!){
-                  addProjectV2ItemById(input:{projectId:$projectId, contentId:$contentId}){ item { id } }
-                }`, { projectId, contentId: node.repository.issue.id });
+              const node = await github.graphql(
+                `query($o:String!, $r:String!, $n:Int!){ repository(owner:$o, name:$r){ issue(number:$n){ id } } }`,
+                { o: context.repo.owner, r: context.repo.repo, n: issueNumber }
+              );
+              await github.graphql(
+                `mutation($projectId:ID!, $contentId:ID!){ addProjectV2ItemById(input:{projectId:$projectId, contentId:$contentId}){ item { id } } }`,
+                { projectId, contentId: node.repository.issue.id }
+              );
             }
 
             const DEFAULT_PROJECT_URL = process.env.DEFAULT_PROJECT_URL || null;
             const DEFAULT_ASSIGNEE = process.env.DEFAULT_ASSIGNEE || '';
             const FALLBACK_ASSIGNEE = process.env.FALLBACK_ASSIGNEE || '';
 
-            let projectInfo = null; // single Project for all seeds (by design)
+            let projectInfo = null;
+            const created = [];
 
-            const created = []; // [{number, uid, meta, createdNew:true}]
             for (const f of files) {
               const raw = fs.readFileSync(f, 'utf8');
               const { meta, rest } = parseHeader(raw);
@@ -149,7 +154,6 @@ jobs:
 
               // project URL: seed value, else repo default, else no add
               const projectUrl = meta.project_url || DEFAULT_PROJECT_URL || null;
-
               const body = `${rest}\n\n<!-- seed-uid:${uid} -->`.trim();
 
               // CREATE
@@ -184,9 +188,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const core = require('@actions/core');
-            const created = JSON.parse(core.getInput('created'));
-
+            // 'core' and 'github' are provided
             // utility: find an issue by 'seed-uid:...' marker
             async function findIssueByUid(uid) {
               const q = `repo:${context.repo.owner}/${context.repo.repo} in:body "seed-uid:${uid}" type:issue`;
@@ -194,6 +196,7 @@ jobs:
               return res.data.items.find(i => !i.pull_request) || null;
             }
 
+            const created = JSON.parse(core.getInput('created'));
             const byUid = Object.fromEntries(created.map(i => [i.uid, i]));
 
             // 1) Newly created epics: write their Children checklist (only once).
@@ -230,15 +233,10 @@ jobs:
 
               // find the epic by UID
               const parent = await findIssueByUid(parentUid);
-              if (!parent) {
-                core.warning(`Child #${item.number} declares parent_uid=${parentUid} but no epic found.`);
-                continue;
-              }
+              if (!parent) { core.warning(`Child #${item.number} parent_uid=${parentUid} not found`); continue; }
 
               // fetch current body to check duplication
-              const parentIssue = await github.rest.issues.get({
-                owner: context.repo.owner, repo: context.repo.repo, issue_number: parent.number
-              });
+              const parentIssue = await github.rest.issues.get({ owner: context.repo.owner, repo: context.repo.repo, issue_number: parent.number });
 
               const line = `- [ ] #${item.number}`;
               const header = "## Children";
@@ -249,17 +247,12 @@ jobs:
                 body = `${body}\n\n${header}\n${line}\n`;
               } else if (!body.includes(line)) {
                 // insert line just after header or append to the existing list
-                body = body.replace(/## Children[^\n]*\n((?:- \[ \] #[0-9]+\n)*)/m, (m, list) => {
-                  return `## Children\n${list || ""}${line}\n`;
-                });
+              body = body.replace(/## Children[^\n]*\n((?:- \[ \] #[0-9]+\n)*)/m, (m, list) => `## Children\n${list || ""}${line}\n`);
               } else {
-                continue; // already linked; skip
+                continue;
               }
 
-              await github.rest.issues.update({
-                owner: context.repo.owner, repo: context.repo.repo,
-                issue_number: parent.number, body
-              });
+              await github.rest.issues.update({ owner: context.repo.owner, repo: context.repo.repo, issue_number: parent.number, body });
             }
           created: ${{ steps.create.outputs.created }}
 
@@ -268,9 +261,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const core = require('@actions/core');
             const { execSync } = require('child_process');
-
             const files = core.getInput('files').split(',').filter(Boolean);
             if (!files.length) { core.info('No seeds to consume'); return; }
 

--- a/.github/workflows/seed-project-items.yml
+++ b/.github/workflows/seed-project-items.yml
@@ -1,0 +1,242 @@
+name: Seed Project Items
+
+on:
+  push:
+    paths:
+      - ".github/project-seeds/pending/**.md"
+  workflow_dispatch:
+
+permissions:
+  contents: write           # needed for the auto "consume seeds" PR
+  issues: write
+  pull-requests: write
+  projects: write
+
+concurrency:
+  group: seed-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  seed:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: List pending seed files
+        id: list
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            git ls-files ".github/project-seeds/pending/**.md" > seeds.txt || true
+          else
+            git diff --name-only ${{ github.sha }}^ ${{ github.sha }} | grep -E "^\.github/project-seeds/pending/.*\.md$" || true > seeds.txt
+          fi
+          echo "files=$(paste -sd, seeds.txt)" >> "$GITHUB_OUTPUT"
+          echo "Seeds:"
+          cat seeds.txt || true
+
+      - name: Create / update issues and add to Project
+        if: steps.list.outputs.files != ''
+        id: create
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const core = require('@actions/core');
+            const fs = require('fs');
+            const path = require('path');
+
+            const files = core.getInput('files').split(',').filter(Boolean);
+            const created = []; // {number, id, uid, title, meta, createdNew}
+            if (!files.length) { core.info('No seeds'); core.setOutput('created','[]'); return; }
+
+            // Helper: parse header block
+            function parseHeader(body) {
+              const m = body.match(/<!--([\s\S]*?)-->/);
+              if (!m) return { meta:{}, rest: body.trim() };
+              const hdr = m[1];
+              const meta = {};
+              hdr.split('\n').forEach(line => {
+                const L = line.trim();
+                if (!L || L.startsWith('#')) return;
+                const idx = L.indexOf(':');
+                if (idx < 0) return;
+                const k = L.slice(0, idx).trim();
+                let v = L.slice(idx+1).trim();
+                try { meta[k] = JSON.parse(v); }
+                catch { meta[k] = v.replace(/^"+|"+$/g,''); }
+              });
+              const rest = body.replace(m[0], '').trim();
+              return { meta, rest };
+            }
+
+            // For Project v2 add, we need project id (from org + number)
+            async function getProjectInfo(projectUrl) {
+              const m = projectUrl?.match(/orgs\/([^/]+)\/projects\/(\d+)/);
+              if (!m) return null;
+              const [_, org, number] = m;
+              const data = await github.graphql(`
+                query($org:String!, $num:Int!) {
+                  organization(login:$org){
+                    projectV2(number:$num){ id }
+                  }
+                }`, { org, num: parseInt(number,10) });
+              return { org, number: parseInt(number,10), projectId: data.organization.projectV2.id };
+            }
+
+            // Add an Issue to Project v2
+            async function addIssueToProject(projectId, issueNodeId) {
+              await github.graphql(`
+                mutation($projectId:ID!, $contentId:ID!){
+                  addProjectV2ItemById(input:{projectId:$projectId, contentId:$contentId}){ item { id } }
+                }`, { projectId, contentId: issueNodeId });
+            }
+
+            // Search existing by uid marker
+            async function findIssueByUid(uid) {
+              const q = `repo:${context.repo.owner}/${context.repo.repo} in:body "seed-uid:${uid}" type:issue`;
+              const res = await github.rest.search.issuesAndPullRequests({ q });
+              return res.data.items.find(i => !i.pull_request) || null;
+            }
+
+            const results = [];
+            // Preload project once (use first seed's project_url)
+            let projectInfo = null;
+
+            for (const f of files) {
+              const raw = fs.readFileSync(f, 'utf8');
+              const { meta, rest } = parseHeader(raw);
+              const title = meta.title || path.basename(f);
+              const labels = Array.isArray(meta.labels) ? meta.labels : (meta.labels ? [meta.labels] : []);
+              const assignees = Array.isArray(meta.assignees) ? meta.assignees : (meta.assignees ? [meta.assignees] : []);
+              const uid = meta.uid || null;
+              const projectUrl = meta.project_url || null;
+
+              // default to create-only snapshot semantics
+              const mode = (meta.mode ?? 'create_only').toString();
+              const frozen = String(meta.frozen ?? 'true') === 'true';
+              const lifecycle = (meta.lifecycle ?? 'seed_only').toString();
+              const createOnly = (mode === 'create_only') || frozen || (lifecycle === 'seed_only');
+
+              // body with hidden uid marker
+              const issueBody = `${rest}\n\n<!-- seed-uid:${uid || 'none'} -->`.trim();
+
+              let existing = null;
+              if (uid) existing = await findIssueByUid(uid);
+
+              let issue, createdNew = false;
+              if (existing && createOnly) {
+                core.info(`Seed ${uid}: issue #${existing.number} exists; create-only → skipping update`);
+                // fetch full issue to get node id later
+                issue = (await github.rest.issues.get({ owner: context.repo.owner, repo: context.repo.repo, issue_number: existing.number })).data;
+              } else if (existing) {
+                core.info(`Seed ${uid}: updating issue #${existing.number}`);
+                issue = (await github.rest.issues.update({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  issue_number: existing.number, title, body: issueBody
+                })).data;
+                if (labels.length) {
+                  await github.rest.issues.addLabels({ owner: context.repo.owner, repo: context.repo.repo, issue_number: existing.number, labels });
+                }
+                if (assignees.length) {
+                  await github.rest.issues.addAssignees({ owner: context.repo.owner, repo: context.repo.repo, issue_number: existing.number, assignees });
+                }
+              } else {
+                core.info(`Seed ${uid || title}: creating new issue`);
+                issue = (await github.rest.issues.create({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  title, body: issueBody, labels, assignees
+                })).data;
+                createdNew = true;
+              }
+
+              // Add to Project
+              if (projectUrl) {
+                if (!projectInfo) projectInfo = await getProjectInfo(projectUrl);
+                if (projectInfo?.projectId) {
+                  // fetch node id for the issue
+                  const nodeQ = await github.graphql(`
+                    query($o:String!, $r:String!, $n:Int!){
+                      repository(owner:$o, name:$r){ issue(number:$n){ id } }
+                    }`,
+                    { o: context.repo.owner, r: context.repo.repo, n: issue.number }
+                  );
+                  await addIssueToProject(projectInfo.projectId, nodeQ.repository.issue.id).catch(e => core.warning(`Add to project failed for #${issue.number}: ${e.message}`));
+                }
+              }
+
+              results.push({ number: issue.number, id: issue.id, uid, title, meta, createdNew });
+            }
+
+            core.setOutput('created', JSON.stringify(results));
+
+      - name: Wire parent/children on newly created epics
+        if: steps.create.outputs.created != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const core = require('@actions/core');
+            const created = JSON.parse(core.getInput('created'));
+            const byUid = Object.fromEntries(created.map(i => [i.uid, i]));
+            for (const item of created) {
+              const meta = item.meta || {};
+              const children = meta.children_uids || [];
+              if (!children.length) continue;
+              // Only inject checklist when epic was created now (avoid rewriting snapshots)
+              if (!item.createdNew) continue;
+
+              // Compose checklist
+              const childNums = children.map(u => byUid[u]?.number).filter(Boolean);
+              if (!childNums.length) continue;
+
+              // Fetch current body
+              const issue = await github.rest.issues.get({
+                owner: context.repo.owner, repo: context.repo.repo, issue_number: item.number
+              });
+
+              const header = "## Children\n";
+              const list = childNums.map(n => `- [ ] #${n}`).join('\n');
+              const body = `${issue.data.body}\n\n${header}${list}\n`;
+
+              await github.rest.issues.update({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: item.number, body
+              });
+            }
+          with:
+            created: ${{ steps.create.outputs.created }}
+
+      - name: Open PR to consume processed seeds (pending → applied)
+        if: steps.list.outputs.files != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const core = require('@actions/core');
+            const { execSync } = require('child_process');
+
+            const files = core.getInput('files').split(',').filter(Boolean);
+            if (!files.length) { core.info('No seeds to consume'); return; }
+
+            const branch = `automation/consume-seeds-${Date.now()}`;
+            execSync('git config user.name "github-actions[bot]"');
+            execSync('git config user.email "41898282+github-actions[bot]@users.noreply.github.com"');
+            execSync(`git checkout -b ${branch}`);
+
+            for (const f of files) {
+              const target = f.replace('/pending/', '/applied/');
+              execSync(`mkdir -p "$(dirname "${target}")"`);
+              execSync(`git mv "${f}" "${target}"`);
+            }
+
+            execSync('git add -A');
+            execSync('git commit -m "chore(automation): consume processed seeds → applied/"');
+            execSync(`git push --set-upstream origin ${branch}`);
+
+            const pr = await github.rest.pulls.create({
+              owner: context.repo.owner, repo: context.repo.repo,
+              head: branch, base: 'main',
+              title: 'chore(automation): consume processed seeds → applied/',
+              body: 'Move processed seeds from pending/ to applied/ to enforce create-only snapshots.'
+            });
+            core.notice(`Opened consume PR #${pr.data.number}`);
+        with:
+          files: ${{ steps.list.outputs.files }}

--- a/.github/workflows/seed-project-items.yml
+++ b/.github/workflows/seed-project-items.yml
@@ -20,19 +20,31 @@ jobs:
   seed:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: Checkout repository (full history so diffs work)
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: List pending seed files
+      - name: List pending seed files (robust on first push & shallow clones)
         id: list
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            git ls-files ".github/project-seeds/pending/**.md" > seeds.txt || true
+          set -euo pipefail
+          BEFORE="${{ github.event.before }}"
+          AFTER="${{ github.sha }}"
+          SEED_GLOB=".github/project-seeds/pending/**.md"
+
+          # First push to a branch often has BEFORE all zeros or unset.
+          if [ -z "${BEFORE}" ] || [ "${BEFORE}" = "0000000000000000000000000000000000000000" ]; then
+            # Just list all seeds in pending/
+            git ls-files "${SEED_GLOB}" > seeds.txt || true
           else
-            git diff --name-only ${{ github.sha }}^ ${{ github.sha }} | grep -E "^\.github/project-seeds/pending/.*\.md$" || true > seeds.txt
+            # Only files touched in this push
+            git diff --name-only "${BEFORE}" "${AFTER}" | grep -E "^\.github/project-seeds/pending/.*\.md$" || true > seeds.txt
           fi
+
           echo "files=$(paste -sd, seeds.txt)" >> "$GITHUB_OUTPUT"
-          echo "Seeds:"; cat seeds.txt || true
+          echo "Seeds:"
+          cat seeds.txt || true
 
       # ▶ CREATE-ONLY: if an issue with this UID already exists, SKIP.
       - name: Create issues (create-only) and add to Project

--- a/.github/workflows/seed-project-items.yml
+++ b/.github/workflows/seed-project-items.yml
@@ -24,7 +24,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
       - name: List pending seed files (robust on first push & shallow clones)
         id: list
         run: |
@@ -35,16 +34,16 @@ jobs:
 
           # First push to a branch often has BEFORE all zeros or unset.
           if [ -z "${BEFORE}" ] || [ "${BEFORE}" = "0000000000000000000000000000000000000000" ]; then
-            # Just list all seeds in pending/
+            # List all tracked seeds in pending/
             git ls-files "${SEED_GLOB}" > seeds.txt || true
           else
-            # Only files touched in this push
-            git diff --name-only "${BEFORE}" "${AFTER}" | grep -E "^\.github/project-seeds/pending/.*\.md$" || true > seeds.txt
+            # Only files touched in this push → group the pipeline, then redirect once
+            ( git diff --name-only "${BEFORE}" "${AFTER}" \
+              | grep -E "^\.github/project-seeds/pending/.*\.md$" || true ) > seeds.txt
           fi
 
           echo "files=$(paste -sd, seeds.txt)" >> "$GITHUB_OUTPUT"
-          echo "Seeds:"
-          cat seeds.txt || true
+          echo "Seeds:"; cat seeds.txt || true
 
       # ▶ CREATE-ONLY: if an issue with this UID already exists, SKIP.
       - name: Create issues (create-only) and add to Project


### PR DESCRIPTION
# Automation — seed Issues/Epics from Markdown

Fixes #22

## Summary
Introduce a workflow that converts Markdown “seed” files into GitHub issues/epics, with idempotent behavior and a visible **Children** checklist in epic bodies.

> ✅ Note: Projects v2 auto-add + **native Parent/Child** relationships are **out of scope** for this PR and tracked in #23.

## What & Why
- Enable fast planning by committing seed files instead of clicking in the UI.
- Ensure re-runs don’t duplicate issues (uses hidden `<!-- seed-uid:... -->` marker).
- Provide a lightweight epic→children linkage via a checklist so progress ticks automatically.

## Changes
- Add workflow: `.github/workflows/seed-project-items.yml`
  - Parses seed headers: `title`, `labels`, `assignees`, `uid`, `parent_uid`, `children_uids`, `type`, `phase`
  - Creates issues if missing; skips if an existing issue with the same `uid` is found
  - Writes/merges an epic **Children** checklist (`- [ ] #<child>`) idempotently
  - Safe when Projects config is missing (logs warnings, doesn’t fail the run)
- Add example seeds (epic + 3 children):  
  `.github/project-seeds/pending/phase1a-epic.md`  
  `.github/project-seeds/pending/phase1a-first-export.md`  
  `.github/project-seeds/pending/phase1a-schema.md`  
  `.github/project-seeds/pending/phase1a-workflow.md`

## How it Works (short)
1. Workflow gathers changed seed files under `.github/project-seeds/pending/**.md`.
2. For each seed, it reads the HTML-comment header and derives metadata.
3. It searches for an existing issue containing `seed-uid:<UID>`:
   - If found (and in create-only mode), it **skips** creation.
   - If not found, it **creates** a new issue with labels/assignees/body.
4. If the seed is an epic with `children_uids`, the epic body gets/updates a **Children** checklist.
5. If a seed has `parent_uid`, the child is appended to the parent’s checklist (only once).

## Out of Scope (moved to #23)
- Adding items to a Projects v2 board
- Writing custom Project fields (Type/Phase)
- Creating **native** Parent/Child relationships so nesting/inheritance appears in Projects

## Testing / Evidence
- [ ] Link to successful workflow run
- [ ] Screenshot of the created epic showing the **Children** checklist

## Risk & Rollback
- Low risk; if anything looks off, remove the created issues and revert the seed files.
- Workflow is gated to the `pending/` path and is idempotent.

## Follow-ups
- #23: Configure tokens/permissions and implement:
  - Projects v2 auto-add via GraphQL
  - Native Parent/Child relationships (so children inherit project and nest in views)

## Reviewer Notes
- Check that IDs (`uid`, `parent_uid`, `children_uids`) in the sample seeds are unique and consistent.
- Verify labels/assignees are applied as expected.
- Confirm re-running the workflow doesn’t create duplicates.
