### PR TITLE
chore(repo): Add python script which generates the repo_content.txt f…

### DIFF
--- a/repo_contents.txt
+++ b/repo_contents.txt
@@ -1,0 +1,192 @@
+.
+├── .github
+│   ├── ISSUE_TEMPLATE
+│   │   ├── spec_review.md
+│   │   └── work_item.md
+│   ├── PULL_REQUEST_TEMPLATE
+│   │   └── consume.md
+│   ├── project-seeds
+│   │   ├── applied
+│   │   │   ├── auto-gh-A.md
+│   │   │   ├── auto-gh-B.md
+│   │   │   ├── auto-gh-C.md
+│   │   │   ├── auto-gh-C1-auto-merge-consume-prs.md
+│   │   │   ├── auto-gh-D.md
+│   │   │   ├── auto-gh-epic.md
+│   │   │   ├── phase1a-epic.md
+│   │   │   ├── phase1a-first-export.md
+│   │   │   ├── phase1a-schema.md
+│   │   │   └── phase1a-workflow.md
+│   │   ├── hold
+│   │   ├── pending
+│   │   │   └── .gitkeep
+│   │   └── library.json
+│   ├── workflows
+│   │   ├── ci.yml
+│   │   ├── consume-auto-merge.yml
+│   │   ├── library-backfill.yml
+│   │   └── seed-project-items.yml
+│   └── pull_request_template.md
+├── .ruff_cache
+│   ├── 0.13.1
+│   │   ├── 15303535225207274766
+│   │   ├── 2734649222373132862
+│   │   ├── 4862196216010610225
+│   │   ├── 9197418806920851759
+│   │   └── 9447696069874308193
+│   ├── 0.6.8
+│   │   ├── 1154151359620513117
+│   │   ├── 12526296425791170776
+│   │   ├── 14792270648220210559
+│   │   ├── 17851464995738533836
+│   │   ├── 3704221467505297124
+│   │   ├── 4879223633704541869
+│   │   ├── 6585194902085170572
+│   │   ├── 8907089595450365449
+│   │   ├── 918489930911913660
+│   │   └── 9379814276718360695
+│   ├── .gitignore
+│   └── CACHEDIR.TAG
+├── .streamlit
+│   ├── config.toml
+│   ├── secrets.toml
+│   └── secrets.toml.example
+├── archive
+├── assets
+│   ├── LogoSurLeFeu.png
+│   ├── LogoSurLeFeunotagline.png
+│   ├── chef_logo.png
+│   └── chef_logo.png:Zone.Identifier
+├── backups
+│   └── backup_20250909_163604.sql
+├── components
+│   ├── active_client_badge.py
+│   └── tenant_switcher.py
+├── config
+│   └── branding_config.json
+├── data
+│   └── sample_data
+│       └── 2025-09-09
+│           ├── public.ingredients.csv
+│           ├── public.profiles.csv
+│           ├── public.recipe_lines.csv
+│           ├── public.recipes.csv
+│           ├── public.ref_ingredient_categories.csv
+│           ├── public.ref_storage_type.csv
+│           ├── public.ref_uom_conversion.csv
+│           └── public.sales.csv
+├── docs
+│   ├── policy
+│   │   ├── branching_and_prs.md
+│   │   ├── ci_cd_constitution.md
+│   │   ├── ci_minimal.md
+│   │   ├── commits_and_changelog.md
+│   │   ├── docs_policy.md
+│   │   ├── env_and_secrets.md
+│   │   ├── issues_workflow.md
+│   │   └── specs_workflow.md
+│   ├── reference
+│   │   └── glossary.md
+│   ├── runbooks
+│   │   ├── github_projects_setup.md
+│   │   └── release_playbook.md
+│   ├── specs
+│   │   └── spec_template.md
+│   └── README.md
+├── migrations
+│   ├── sql
+│   │   ├── V001__create_tenants_and_memberships.sql
+│   │   ├── V002__add_tenant_id.sql
+│   │   ├── V003__soft_delete.sql
+│   │   ├── V004__uniques_and_indexes.sql
+│   │   ├── V005__cross_tenant_guards.sql
+│   │   ├── V006__rls_enable_and_policies.sql
+│   │   ├── V007__fix_uniques_make_uom_global_and_update_views.sql
+│   │   ├── V008__cross_tenant_guards_and_policies.sql
+│   │   ├── V009__tenant_functions_add.sql
+│   │   ├── V010__normalize_rls_for_global_uom.sql
+│   │   └── V011__tenant_branding_and_default.sql
+│   ├── 20250916-223441__release_0.6.0.sql
+│   └── MIGRATION_PLAN__V010_tenant_claim_rls.md
+├── pages
+│   ├── Clients.py
+│   ├── IngredientCategories.py
+│   ├── Ingredients.py
+│   ├── RecipeEditor.py
+│   ├── Recipes.py
+│   ├── Settings.py
+│   └── UOM_Conversion.py
+├── patches
+├── schema
+│   ├── archive
+│   │   ├── 2025_09_24_2011_prod.sql
+│   │   ├── supabase_schema_2025-07-08.sql
+│   │   ├── supabase_schema_2025-09-03.sql
+│   │   ├── supabase_schema_2025-09-04_01.sql
+│   │   ├── supabase_schema_2025-09-05_01.sql
+│   │   ├── supabase_schema_2025-09-08_01.sql
+│   │   ├── supabase_schema_2025-09-09_01.sql
+│   │   ├── supabase_schema_2025-09-10_01.sql
+│   │   ├── supabase_schema_2025-09-11_01.sql
+│   │   ├── supabase_schema_2025-09-15_01.sql
+│   │   └── supabase_schema_2025-09-16_01.sql
+│   ├── current
+│   │   └── prod.schema.sql
+│   ├── migrations
+│   │   └── recipes_as_ingredients_v0.1.3
+│   │       └── recipes_as_ingredients_v0.1.3.sql
+│   ├── releases
+│   └── .gitkeep
+├── scripts
+│   ├── lib
+│   │   ├── json_io.js
+│   │   ├── seed_parse.js
+│   │   └── uid_resolver.js
+│   ├── add_db_imports.py
+│   ├── codemod_supabase_calls.py
+│   ├── codemod_supabase_multiline_selects.py
+│   └── codemod_updates_and_deletes.py
+├── shortcuts
+│   ├── App.bat
+│   ├── ChatGPTProject.bat
+│   ├── MVP_MenuOptimizer_Workspace.bat
+│   ├── VSCode-old.bat
+│   ├── codex.bat
+│   ├── github.bat
+│   ├── runApp.bat
+│   └── supabase.bat
+├── utils
+│   ├── __init__.py
+│   ├── auth.py
+│   ├── branding.py
+│   ├── cache.py
+│   ├── data.py
+│   ├── db.py
+│   ├── supabase.py
+│   ├── tenant_db.py
+│   ├── tenant_state.py
+│   ├── theme.py
+│   └── version.py
+├── .editorconfig
+├── .env
+├── .env.example
+├── .gitattributes
+├── .gitignore
+├── .pre-commit-config.yaml
+├── AGENTS.md
+├── CHANGELOG.md
+├── CONTRIBUTING.md
+├── Home.py
+├── README.md
+├── VERSION
+├── archive_merged.sh
+├── dump_sample_data.sh
+├── dump_schema.sh
+├── menu_optimizer.code-workspace
+├── migrate.sh
+├── pyproject.toml
+├── repo_tree.py
+├── requirements-dev.txt
+├── requirements.txt
+├── seed_supabase.py
+└── setup.sh

--- a/repo_tree.py
+++ b/repo_tree.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# repo_tree.py
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+EXCLUDES_DEFAULT = {".git", ".venv", "node_modules", "__pycache__", ".idea", ".vscode"}
+
+DirMap = Dict[Path, Tuple[List[Path], List[Path]]]
+
+
+def build_dir_map(root: Path, excludes: set[str]) -> DirMap:
+    """
+    Build a mapping of each directory (relative to root) to its (dirs, files),
+    already filtered and sorted. Excludes apply by name at any level.
+    """
+    dir_map: DirMap = {}
+    root = root.resolve()
+
+    for current, dirnames, filenames in os.walk(root, topdown=True):
+        # Filter directories in-place so os.walk won't descend into excluded dirs
+        dirnames[:] = [d for d in dirnames if d not in excludes]
+        # Filter files by simple name match as well
+        files = [f for f in filenames if f not in excludes]
+
+        cur_path = Path(current)
+        rel_dir = cur_path.relative_to(root)
+
+        # Build relative Paths for children
+        rel_dirs = sorted((rel_dir / d) for d in dirnames)
+        rel_files = sorted((rel_dir / f) for f in files)
+
+        dir_map.setdefault(rel_dir, ([], []))
+        dir_map[rel_dir] = (rel_dirs, rel_files)
+
+    # Ensure missing parents exist in map (in case root is empty, etc.)
+    if Path(".") not in dir_map:
+        dir_map[Path(".")] = ([], [])
+    return dir_map
+
+
+def render_tree(dir_map: DirMap) -> str:
+    lines: List[str] = []
+    lines.append(".")
+
+    def draw(dir_path: Path, prefix: str = ""):
+        dirs, files = dir_map.get(dir_path, ([], []))
+        # Render directories first, then files
+        items = [("dir", d) for d in dirs] + [("file", f) for f in files]
+
+        for i, (kind, p) in enumerate(items):
+            is_last = i == len(items) - 1
+            connector = "└── " if is_last else "├── "
+            lines.append(f"{prefix}{connector}{p.name}")
+
+            if kind == "dir":
+                # For the child directory, fetch its own children
+                # and continue recursion with an extended prefix
+                child_prefix = f"{prefix}{'    ' if is_last else '│   '}"
+                draw(p, child_prefix)
+
+    draw(Path("."))
+    return "\n".join(lines)
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Write a folder+file tree to a .txt file (like `tree`)."
+    )
+    ap.add_argument("path", nargs="?", default=".", help="Repo root (default: current dir)")
+    ap.add_argument(
+        "--out", default="repo_contents.txt", help="Output file (default: repo_contents.txt)"
+    )
+    ap.add_argument(
+        "--exclude",
+        default=",".join(sorted(EXCLUDES_DEFAULT)),
+        help=f"Comma-separated names to exclude (default: {','.join(sorted(EXCLUDES_DEFAULT))})",
+    )
+    args = ap.parse_args()
+
+    root = Path(args.path).resolve()
+    excludes = {x.strip() for x in args.exclude.split(",")} if args.exclude else set()
+
+    dir_map = build_dir_map(root, excludes)
+    txt = render_tree(dir_map)
+
+    Path(args.out).write_text(txt, encoding="utf-8")
+    print(f"Wrote {args.out} (root: {root})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!--
Intent-first PR template
Read the checklist; delete guidance before submitting.
Terms link to the Glossary: docs/reference/glossary.md
-->

# Because
I want to share the current updated and de-cluttered repo structure with collaborators and bots.

# Changed
I added a python script (repo_tree.py) to auto generate the contents of repo_structure.txt containing folders and files, automatically, skipping common "junk".

# Result
We now have a working script and an up to date repo_contents.txt file.

# Done when
- [x] Script is working
- [x] repo_contents.txt is generated and accurate.

# Changelog
Added — repo_tree.py to generate a snapshot of the current repo contents (folders and files).

# Notes
Usage:
```
# From your repo root
python3 repo_tree.py .

# Anywhere (point to a repo)
python3 repo_tree.py /home/mathieu/mvp_apps/menu_optimizer

# Custom excludes/output
python3 repo_tree.py . --exclude ".git,node_modules,.venv,__pycache__" --out repo_contents.txt
```

---

## Meta

- Branch: `chore/repo-tree`
- Conventional commit prefix for squash: `chore(repo): Add python script which generates the repo_content.txt

