### PR TITLE
chore(scripts): align migrate.sh with Bitwarden project secrets (#169)

### DIFF
--- a/docs/policy/migrations_and_schema.md
+++ b/docs/policy/migrations_and_schema.md
@@ -48,6 +48,24 @@ Purpose: keep database drift under control while the MVP evolves. Pair with `dum
 
 ---
 
+## Running Migrations
+
+### MVP now
+- Choose the Bitwarden project explicitly:
+  - `./migrate.sh --env staging up --dry-run`  
+    (`--env <name>` must match an export in `.envrc`; use `--project-id <uuid>` when running outside direnv.)
+  - Drop `--dry-run` to apply changes once the plan looks clean.
+- Optional driver override: `./migrate.sh --env staging --driver postgresql+psycopg up`.
+- Idempotent bookkeeping:
+  - `./migrate.sh --env staging mark V012__backfill.sql`
+  - `./migrate.sh --env staging mark-before V015__cutoff.sql`
+- The script resolves `DATABASE_URL` via `bws run --project-id=… -- python -m utils.db`; no `.env` sourcing or legacy `DB_URL` fallbacks remain.
+
+### v1 later
+- Wire migrations into CI sandbox runs and require automated dry-runs before production promotion.
+
+---
+
 ## Data Safety
 
 - Avoid destructive ops (`DROP`, `DELETE`) unless the accompanying spec approves it.  

--- a/docs/runbooks/db_security_hardening.md
+++ b/docs/runbooks/db_security_hardening.md
@@ -2,7 +2,7 @@
 
 ## Steps (staging → prod)
 
-1. Apply migrations V012–V014 with ./migrate.sh up (dry-run first).
+1. Apply migrations V012–V014 with `./migrate.sh --env staging up --dry-run` (then rerun without `--dry-run`).
 2. Console toggles:
    - Auth → Passwords → Leaked password protection = ON
    - Database → Upgrade to latest 17.6.1.011 patch

--- a/migrate.sh
+++ b/migrate.sh
@@ -1,46 +1,187 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# --- Config & env loading -----------------------------------------------------
-
-# Auto-load .env if DB vars not set
-if [ -z "${DB_URL:-}" ] && [ -z "${SUPABASE_DB_URL:-}" ] && [ -z "${DATABASE_URL:-}" ] && [ -f ".env" ]; then
-  set -a
-  . ./.env
-  set +a
-fi
-
-# Final DB URL fallback chain
-DB_URL="${DB_URL:-${SUPABASE_DB_URL:-${DATABASE_URL:-}}}"
-
-# Multiple dirs, colon-separated (searched in order)
-# Default looks in migrations/sql first, then migrations
 MIGRATIONS_DIRS="${MIGRATIONS_DIRS:-migrations/sql:migrations}"
-
-CMD="${1:-}"; shift || true
+ENV_NAME=""
+PROJECT_ID=""
+DRIVER_OVERRIDE="${DB_DRIVER:-}"
 
 usage() {
-  cat <<EOF
+  cat <<'EOF'
 Usage:
-  ./migrate.sh up [--dry-run]
-  ./migrate.sh mark <Vxxx__name.sql|.sh|.py ...>
-  ./migrate.sh mark-before <Vxxx__cutoff.sql>
+  ./migrate.sh --env <name> up [--dry-run]
+  ./migrate.sh --env <name> mark <Vxxx__name.sql|.sh|.py ...>
+  ./migrate.sh --env <name> mark-before <Vxxx__cutoff.sql>
 
-Env:
-  DB_URL / SUPABASE_DB_URL / DATABASE_URL : Postgres connection string
-  MIGRATIONS_DIRS                         : colon-separated dirs (default: migrations/sql:migrations)
+Options:
+  --env <name>          Environment label (e.g., staging, prod); must map to a Bitwarden project id via .envrc.
+  --project-id <uuid>   Bitwarden project id (skip --env when provided).
+  --driver <name>       Optional driver override passed to utils.db (e.g., postgresql+psycopg).
+  --help                Show this help message.
 
 Notes:
+  - Resolves DATABASE_URL through Bitwarden secrets using `python -m utils.db`.
   - Runs V*.sql with psql in a single transaction (-1), V*.sh with bash, V*.py with python3.
   - Creates public.schema_migrations if missing:
       (filename text PK, checksum text NOT NULL, executed_at timestamptz NOT NULL)
   - Files are tracked by BASENAME; you can move them across dirs safely.
 EOF
+  exit 1
 }
 
+CMD=""
+CMD_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env)
+      ENV_NAME="${2:-}"
+      shift 2
+      ;;
+    --project-id)
+      PROJECT_ID="${2:-}"
+      shift 2
+      ;;
+    --driver)
+      DRIVER_OVERRIDE="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      ;;
+    up|mark|mark-before)
+      CMD="$1"
+      shift
+      CMD_ARGS=("$@")
+      break
+      ;;
+    *)
+      echo "Unknown option or command: $1" >&2
+      usage
+      ;;
+  esac
+done
+
+if [[ -z "${CMD}" ]]; then
+  usage
+fi
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || { echo "$1 not found." >&2; exit 1; }
+}
+
+resolve_python_bin() {
+  local candidate="${PYTHON_BIN:-python}"
+  if command -v "${candidate}" >/dev/null 2>&1; then
+    echo "${candidate}"
+    return
+  fi
+  candidate="python3"
+  if command -v "${candidate}" >/dev/null 2>&1; then
+    echo "${candidate}"
+    return
+  fi
+  return 1
+}
+
+extract_project_id() {
+  local env_name="$1"
+  local varname="${env_name^^}"
+
+  if [[ -n "${!varname:-}" ]]; then
+    echo "${!varname}"
+    return
+  fi
+
+  if [[ -f .envrc ]]; then
+    while IFS= read -r line; do
+      line="${line%%#*}"
+      [[ -z "${line// }" ]] && continue
+      if [[ "${line}" =~ ^[[:space:]]*export[[:space:]]+${varname}=(\"?)([^\"[:space:]]+)\1 ]]; then
+        echo "${BASH_REMATCH[2]}"
+        return
+      fi
+    done < .envrc
+  fi
+}
+
+fetch_database_url() {
+  local python_bin="$1"
+  local project_id="$2"
+  local driver="$3"
+
+  if [[ -n "${driver}" ]]; then
+    DB_DRIVER_OVERRIDE="${driver}" bws run --project-id="${project_id}" -- "${python_bin}" - <<'PY'
+from utils import db
+import os, sys
+driver = os.environ.get("DB_DRIVER_OVERRIDE")
+sys.stdout.write(db.database_url(driver))
+PY
+  else
+    bws run --project-id="${project_id}" -- "${python_bin}" -m utils.db
+  fi
+}
+
+setup_connection() {
+  require_command bws
+
+  local python_bin
+  python_bin="$(resolve_python_bin)" || {
+    echo "python (or python3) not found in PATH." >&2
+    exit 1
+  }
+
+  local project="${PROJECT_ID}"
+  if [[ -z "${project}" ]]; then
+    if [[ -z "${ENV_NAME}" ]]; then
+      echo "Provide --env <name> or --project-id <uuid> to select a Bitwarden project." >&2
+      exit 1
+    fi
+    project="$(extract_project_id "${ENV_NAME}")"
+    if [[ -z "${project}" ]]; then
+      echo "Could not resolve Bitwarden project id for env '${ENV_NAME}'. Ensure '${ENV_NAME^^}' is exported or present in .envrc." >&2
+      exit 1
+    fi
+  fi
+
+  local url
+  url="$(fetch_database_url "${python_bin}" "${project}" "${DRIVER_OVERRIDE}")" || {
+    echo "Unable to synthesize DATABASE_URL via Bitwarden project ${project}." >&2
+    exit 1
+  }
+  if [[ -z "${url}" ]]; then
+    echo "utils.db returned an empty DATABASE_URL for project ${project}." >&2
+    exit 1
+  fi
+
+  DB_URL="${url}"
+  BITWARDEN_PROJECT_ID="${project}"
+}
+
+setup_connection
+
+# --- File discovery & bookkeeping --------------------------------------------
+
+readarray -d : -t __DIRS__ <<<"${MIGRATIONS_DIRS}:"
+
+gather_migration_files() {
+  local files=()
+  for d in "${__DIRS__[@]}"; do
+    [[ -d "$d" ]] || continue
+    while IFS= read -r -d '' f; do files+=("$f"); done \
+      < <(LC_ALL=C find "$d" -maxdepth 1 -type f -regextype posix-extended \
+            -regex '.*/V[0-9]{3}__.*\.(sql|sh|py)$' -print0)
+  done
+  printf '%s\n' "${files[@]}" | awk -F/ '{print $NF "|" $0}' | LC_ALL=C sort | cut -d'|' -f2
+}
+
+basename_only() { basename "$1"; }
+
+# --- Requirements -------------------------------------------------------------
+
 require_db() {
-  if [[ -z "${DB_URL}" ]]; then
-    echo "DB_URL (or SUPABASE_DB_URL or DATABASE_URL) is not set" >&2
+  if [[ -z "${DB_URL:-}" ]]; then
+    echo "DATABASE_URL could not be resolved." >&2
     exit 1
   fi
 }
@@ -74,50 +215,32 @@ create table if not exists public.schema_migrations (
 SQL
 }
 
-# --- File discovery & bookkeeping --------------------------------------------
-
-# Split MIGRATIONS_DIRS by ':'
-readarray -d : -t __DIRS__ <<<"${MIGRATIONS_DIRS}:"
-
-gather_migration_files() {
-  local files=()
-  for d in "${__DIRS__[@]}"; do
-    [[ -d "$d" ]] || continue
-    # Collect V*.sql/.sh/.py (not recursive; predictable)
-    while IFS= read -r -d '' f; do files+=("$f"); done \
-      < <(LC_ALL=C find "$d" -maxdepth 1 -type f -regextype posix-extended \
-            -regex '.*/V[0-9]{3}__.*\.(sql|sh|py)$' -print0)
-  done
-  # Sort by BASENAME so V### order is respected across directories
-  printf '%s\n' "${files[@]}" | awk -F/ '{print $NF "|" $0}' | LC_ALL=C sort | cut -d'|' -f2
-}
-
-basename_only() { basename "$1"; }
-
 is_applied() {
-  local base="$(basename_only "$1")"
+  local base
+  base="$(basename_only "$1")"
   psql "${DB_URL}" -t -A -q -X -c \
     "select 1 from public.schema_migrations where filename = '${base}' limit 1;" \
-    | grep -q '^1$' && return 0 || return 1
+    | grep -q '^1$'
 }
 
 record_applied() {
   local file="$1"
-  local base="$(basename_only "$file")"
-  local sum; sum="$(sha256_of "$file")"
+  local base sum
+  base="$(basename_only "$file")"
+  sum="$(sha256_of "$file")"
   psql "${DB_URL}" -v ON_ERROR_STOP=1 -q -X -c \
     "insert into public.schema_migrations(filename, checksum) values ('${base}', '${sum}')
      on conflict (filename) do update set checksum = excluded.checksum, executed_at = now();"
 }
 
-# Resolve a basename to a real path by searching MIGRATIONS_DIRS
 resolve_by_basename() {
   local target_base="$1"
   for d in "${__DIRS__[@]}"; do
     [[ -d "$d" ]] || continue
     local candidate="${d}/${target_base}"
     if [[ -f "$candidate" ]]; then
-      echo "$candidate"; return 0
+      echo "$candidate"
+      return 0
     fi
   done
   return 1
@@ -128,19 +251,16 @@ resolve_by_basename() {
 run_sql() {
   require_psql
   local file="$1"
-  # -1 single transaction; -X no .psqlrc; -q quiet; ON_ERROR_STOP aborts on first error
   psql "${DB_URL}" -v ON_ERROR_STOP=1 -q -X -1 -f "$file"
 }
 
 run_sh() {
   local file="$1"
-  # Export DB_URL so scripts can psql with it or do other DB work
   DB_URL="${DB_URL}" bash -euo pipefail "$file"
 }
 
 run_py() {
   local file="$1"
-  # Python scripts can read DB_URL from the environment
   DB_URL="${DB_URL}" python3 "$file"
 }
 
@@ -158,7 +278,10 @@ apply_file() {
 
 cmd_up() {
   local dry="no"
-  if [[ "${1:-}" == "--dry-run" ]]; then dry="yes"; shift || true; fi
+  if [[ "${1:-}" == "--dry-run" ]]; then
+    dry="yes"
+    shift || true
+  fi
 
   require_db
   mk_migrations_table
@@ -170,7 +293,8 @@ cmd_up() {
   fi
 
   for f in "${files[@]}"; do
-    local base="$(basename_only "$f")"
+    local base
+    base="$(basename_only "$f")"
     if is_applied "$f"; then
       echo "✓ SKIP  $base (already applied)"
       continue
@@ -187,15 +311,20 @@ cmd_up() {
 }
 
 cmd_mark() {
+  local args=("$@")
   require_db
   mk_migrations_table
-  if [[ $# -lt 1 ]]; then echo "mark requires at least one filename (basename or path)"; exit 1; fi
-  for arg in "$@"; do
+  if [[ ${#args[@]} -lt 1 ]]; then
+    echo "mark requires at least one filename (basename or path)" >&2
+    exit 1
+  fi
+
+  for arg in "${args[@]}"; do
     local f="$arg"
     if [[ ! -f "$f" ]]; then
-      # try resolve by basename across dirs
       if ! f="$(resolve_by_basename "$(basename_only "$arg")")"; then
-        echo "Not found in MIGRATIONS_DIRS: $arg" >&2; exit 1
+        echo "Not found in MIGRATIONS_DIRS: $arg" >&2
+        exit 1
       fi
     fi
     echo "→ MARK $(basename_only "$f")"
@@ -204,15 +333,20 @@ cmd_mark() {
 }
 
 cmd_mark_before() {
+  local args=("$@")
   require_db
   mk_migrations_table
-  local cutoff="${1:-}"
-  if [[ -z "$cutoff" ]]; then echo "mark-before requires a cutoff filename"; exit 1; fi
+  local cutoff="${args[0]:-}"
+  if [[ -z "$cutoff" ]]; then
+    echo "mark-before requires a cutoff filename" >&2
+    exit 1
+  fi
 
   mapfile -t files < <(gather_migration_files)
   local found="no"
   for f in "${files[@]}"; do
-    local base="$(basename_only "$f")"
+    local base
+    base="$(basename_only "$f")"
     if [[ "$base" < "$cutoff" ]]; then
       echo "→ MARK $base"
       record_applied "$f"
@@ -227,9 +361,8 @@ cmd_mark_before() {
 }
 
 case "$CMD" in
-  up)            cmd_up "$@";;
-  mark)          cmd_mark "$@";;
-  mark-before)   cmd_mark_before "$@";;
-  ""|help|-h|--help) usage;;
-  *) echo "Unknown command: $CMD"; usage; exit 1;;
+  up)            cmd_up "${CMD_ARGS[@]}";;
+  mark)          cmd_mark "${CMD_ARGS[@]}";;
+  mark-before)   cmd_mark_before "${CMD_ARGS[@]}";;
+  *) echo "Unknown command: $CMD"; usage;;
 esac


### PR DESCRIPTION
### PR Body — chore(scripts): align migrate.sh with Bitwarden-driven secrets

# Because
`migrate.sh` still relied on `DB_URL`/`.env` fallbacks, forcing operators to wrap it in `bws run` manually.

# Changed
- Added explicit `--env <name>` / `--project-id <uuid>` flags; the script maps the env to a Bitwarden project (via `.envrc`) and resolves the connection string itself.
- Shells out to `bws run --project-id=… -- python -m utils.db`, supporting `--driver <name>` for SQLAlchemy dialect overrides.
- Removed `.env` autoloading and the legacy `DB_URL`/`SUPABASE_DB_URL` cascade; all subcommands use the Bitwarden-derived URL.
- Updated `docs/policy/migrations_and_schema.md` and `docs/runbooks/db_security_hardening.md` to document the new workflow.

# Result
`./migrate.sh --env staging up --dry-run` now runs migrations with Bitwarden-injected secrets and clear failure modes, without extra wrapper scripts.

# Done when
- [x] Command succeeds for `--env staging` dry-run.
- [x] Script errors helpfully when the Bitwarden project cannot be resolved.
- [x] Documentation reflects the new CLI usage and naming.

# Out of scope
- Runtime changes to individual migrations or application code.

# Flags
- None.

# Migrations
- None authored.

# Observability
- Not applicable.

# Risks / Rollback
If automated Bitwarden resolution breaks on another workstation, restore the previous `migrate.sh`.

# Changelog
Changed — `migrate.sh` now accepts `--env/--project-id`, resolves `DATABASE_URL` via Bitwarden, and drops legacy env fallbacks.

Refs: docs/policy/migrations_and_schema.md, docs/runbooks/db_security_hardening.md  
Closes #169
