### PR TITLE
feat(ui): ENV-aware banner + preview subdomain setup

### DIFF
--- a/Home.py
+++ b/Home.py
@@ -7,12 +7,20 @@ from components.active_client_badge import render as client_badge
 from utils.auth import require_auth
 from utils.branding import apply_branding_to_sidebar, inject_brand_colors
 from utils.data import load_recipes_summary
+from utils.env import env_label, is_prod
 from utils.theme import get_primary_color
+
+# Page chrome
+title_suffix = "" if is_prod() else f" — {env_label()}"
+st.set_page_config(page_title=f"Menu Optimizer{title_suffix}", layout="wide")
+
+# Non-prod banner
+if not is_prod():
+    st.warning(f"{env_label()} environment — data and behavior may differ from production.")
 
 require_auth()
 
 # Setup
-st.set_page_config(page_title="Home", layout="wide")
 client_badge(clients_page_title="Clients")
 
 st.markdown(f"<h1 style='color:{get_primary_color()}'>🏠 Home</h1>", unsafe_allow_html=True)

--- a/pages/Clients.py
+++ b/pages/Clients.py
@@ -5,10 +5,18 @@ from st_aggrid import AgGrid, GridOptionsBuilder, GridUpdateMode
 from components.active_client_badge import render as client_badge
 from utils import tenant_db as db
 from utils.auth import require_auth
+from utils.env import env_label, is_prod
 from utils.tenant_state import get_active_tenant, set_active_tenant
 
+# Page chrome
+title_suffix = "" if is_prod() else f" — {env_label()}"
+st.set_page_config(page_title=f"Clients{title_suffix}", layout="wide")
+
+# Non-prod banner
+if not is_prod():
+    st.warning(f"{env_label()} environment — data and behavior may differ from production.")
+
 require_auth()
-st.set_page_config(page_title="Clients", layout="wide")
 client_badge(clients_page_title="Clients")
 st.title("🪪 Clients")
 

--- a/pages/IngredientCategories.py
+++ b/pages/IngredientCategories.py
@@ -5,11 +5,19 @@ from st_aggrid import AgGrid, GridOptionsBuilder, GridUpdateMode
 from components.active_client_badge import render as client_badge
 from utils import tenant_db as db
 from utils.auth import require_auth
+from utils.env import env_label, is_prod
+
+# Page chrome
+title_suffix = "" if is_prod() else f" — {env_label()}"
+st.set_page_config(page_title=f"Ingredient Categories{title_suffix}", layout="wide")
+
+# Non-prod banner
+if not is_prod():
+    st.warning(f"{env_label()} environment — data and behavior may differ from production.")
 
 require_auth()
 
 
-st.set_page_config(page_title="Ingredient Categories", layout="wide")
 client_badge(clients_page_title="Clients")
 st.title("📋 Ingredient Categories")
 

--- a/pages/Ingredients.py
+++ b/pages/Ingredients.py
@@ -5,9 +5,17 @@ from st_aggrid import AgGrid, GridOptionsBuilder, GridUpdateMode
 from components.active_client_badge import render as client_badge
 from utils import tenant_db as db
 from utils.auth import require_auth
+from utils.env import env_label, is_prod
+
+# Page chrome
+title_suffix = "" if is_prod() else f" — {env_label()}"
+st.set_page_config(page_title=f"Ingredients{title_suffix}", layout="wide")
+
+# Non-prod banner
+if not is_prod():
+    st.warning(f"{env_label()} environment — data and behavior may differ from production.")
 
 require_auth()
-st.set_page_config(page_title="Ingredients", layout="wide")
 client_badge(clients_page_title="Clients")
 st.title("🥦 Ingredients")
 

--- a/pages/RecipeEditor.py
+++ b/pages/RecipeEditor.py
@@ -6,7 +6,16 @@ from st_aggrid import AgGrid, GridOptionsBuilder, GridUpdateMode
 from components.active_client_badge import render as client_badge
 from utils import tenant_db as db
 from utils.cache import cache_by_tenant
+from utils.env import env_label, is_prod
 from utils.supabase_client import supabase
+
+# Page chrome
+title_suffix = "" if is_prod() else f" — {env_label()}"
+st.set_page_config(page_title=f"Recipe Editor{title_suffix}", layout="wide")
+
+# Non-prod banner
+if not is_prod():
+    st.warning(f"{env_label()} environment — data and behavior may differ from production.")
 
 # Auth wrapper (optional in MVP env)
 try:
@@ -16,7 +25,6 @@ try:
 except Exception:
     pass
 
-st.set_page_config(page_title="Recipe Editor", layout="wide")
 client_badge(clients_page_title="Clients")
 st.title("📝 Recipe Editor")
 

--- a/pages/Recipes.py
+++ b/pages/Recipes.py
@@ -25,8 +25,15 @@ from st_aggrid import AgGrid, DataReturnMode, GridOptionsBuilder, GridUpdateMode
 
 from components.active_client_badge import render as client_badge
 from utils import tenant_db as db
+from utils.env import env_label, is_prod
 
-st.set_page_config(page_title="Recipes", layout="wide")
+# Page chrome
+title_suffix = "" if is_prod() else f" — {env_label()}"
+st.set_page_config(page_title=f"Recipes{title_suffix}", layout="wide")
+
+# Non-prod banner
+if not is_prod():
+    st.warning(f"{env_label()} environment — data and behavior may differ from production.")
 
 client_badge(clients_page_title="Clients")
 

--- a/pages/Settings.py
+++ b/pages/Settings.py
@@ -6,10 +6,18 @@ import streamlit as st
 from components.active_client_badge import render as client_badge
 from utils import tenant_db as db
 from utils.auth import require_auth
+from utils.env import env_label, is_prod
+
+# Page chrome
+title_suffix = "" if is_prod() else f" — {env_label()}"
+st.set_page_config(page_title=f"Settings{title_suffix}", layout="wide")
+
+# Non-prod banner
+if not is_prod():
+    st.warning(f"{env_label()} environment — data and behavior may differ from production.")
 
 require_auth()
 
-st.set_page_config(page_title="⚙️ Settings", layout="wide")
 client_badge(clients_page_title="Clients")
 st.title("⚙️ Settings")
 

--- a/pages/UOM_Conversion.py
+++ b/pages/UOM_Conversion.py
@@ -5,10 +5,18 @@ from st_aggrid import AgGrid, GridOptionsBuilder, GridUpdateMode
 from components.active_client_badge import render as client_badge
 from utils import tenant_db as db
 from utils.auth import require_auth
+from utils.env import env_label, is_prod
+
+# Page chrome
+title_suffix = "" if is_prod() else f" — {env_label()}"
+st.set_page_config(page_title=f"UOM Conversions{title_suffix}", layout="wide")
+
+# Non-prod banner
+if not is_prod():
+    st.warning(f"{env_label()} environment — data and behavior may differ from production.")
 
 require_auth()
 
-st.set_page_config(page_title="UOM Conversions", layout="wide")
 client_badge(clients_page_title="Clients")
 st.title("UOM Conversions")
 

--- a/utils/env.py
+++ b/utils/env.py
@@ -1,0 +1,33 @@
+import os
+
+import streamlit as st
+
+
+def get_env() -> str:
+    # 1) Local override (supports `bws run`, direnv, .env exports)
+    v = os.environ.get("APP_ENV")
+    if v and str(v).strip():
+        return str(v).strip().lower()
+    # 2) Streamlit Cloud (secrets)
+    if "APP_ENV" in st.secrets:
+        return str(st.secrets["APP_ENV"]).strip().lower()
+    # 3) Default
+    return "prod"
+
+
+def env_label() -> str:
+    e = get_env()
+    return {
+        "prod": "PRODUCTION",
+        "production": "PRODUCTION",
+        "preview": "PREVIEW",
+        "preprod": "PRE-PROD",
+        "qa": "QA",
+        "uat": "UAT",
+        "test": "TEST",
+        "dev": "DEV",
+    }.get(e, e.upper())
+
+
+def is_prod() -> bool:
+    return get_env() in {"prod", "production"}


### PR DESCRIPTION
Summary
- Add environment helper (APP_ENV via secrets/env).
- Show non-prod banner; add env suffix to page title when not prod.
- Document preview/prod secrets and subdomains.

Changes
- app/utils/env.py (new): helpers get_env(), env_label(), is_prod().
- Home.py: page title suffix + banner logic.
- Docs: note on APP_ENV usage (preview vs prod).

Secrets / Env
- Preview app: APP_ENV="preview"
- Prod app:    APP_ENV="prod"
- DEFAULT_TENANT_ID remains set per environment.

Test Plan
- Locally: export APP_ENV=preview → banner visible; APP_ENV=prod → banner hidden.
- Streamlit Cloud: set secrets accordingly; verify title and banner behavior.

Risk
- Low; display-only.
