### PR TITLE
fix(ci): workflow now runs on branch head (like before) 

### DIFF
--- a/.github/workflows/auto-link-subissues.yml
+++ b/.github/workflows/auto-link-subissues.yml
@@ -28,7 +28,9 @@ jobs:
       - name: Checkout (use triggering ref)
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref }}
+          # Fetch full history so we can pick up consume PR merges that happened post-run
+          fetch-depth: 0
 
       - name: Link from library.json
         uses: actions/github-script@v7


### PR DESCRIPTION
fix(ci): workflow now runs on branch head (like before) and not on the commit which triggered the run (which is missing the process seeds in the library).