### PR TITLE
fix(ci): remove "Seed Project Items" trigger because it make the auto…

### DIFF
--- a/.github/workflows/auto-link-subissues.yml
+++ b/.github/workflows/auto-link-subissues.yml
@@ -7,7 +7,7 @@ on:
       - "scripts/lib/link_sub_issue.js"
       - ".github/project-seeds/library.json"
   workflow_run:
-    workflows: ["Library Backfill", "Seed Project Items"]
+    workflows: ["Library Backfill"]
     types: [completed]
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
fix(ci): remove "Seed Project Items" trigger because it make the auto link workflow run before the library is updated.